### PR TITLE
Enhancement to MessageVPNLimits Monitor, minor fixes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ A restart of the `solgeneos` service will then activate the new monitors.
 1. Extract the tar archive at a suitable location on your build machine  
     `tar -xvf sol-geneossample-*.tar.gz`
 1. Clone the git repo to the same directory (or download the zip and extract contents)   
-    `git clone https://github.com/SolaceLabs/solgeneos-custom-monitors`  
+    `git clone https://github.com/SolaceLabs/solace-custom-monitor-solgeneos`  
 1. Merge/replace the contents of the repo with the `solgeneossample` directory contents  
-    `cp solgeneos-custom-monitors/build.* solgeneossample/`  
-    `cp -r solgeneos-custom-monitors/config solgeneossample/`  
-    `cp -r solgeneos-custom-monitors/src solgeneossample/`  
+    `cp solace-custom-monitor-solgeneos/build.* solgeneossample/`  
+    `cp -r solace-custom-monitor-solgeneos/config solgeneossample/`  
+    `cp -r solace-custom-monitor-solgeneos/src solgeneossample/`  
 1. Copy `httpclient` library supplied with `solgeneossample` to `bundledLib` directory  
     `cp solgeneossample/lib/compileLib/httpclient-*.jar solgeneossample/lib/bundledLib/`  
 1. Install Ant and 1.8 JDK if required and set JAVA_HOME  
@@ -228,7 +228,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 
 ## Authors
 
-See the list of [contributors](https://github.com/solacese/solgeneos-custom-monitors/graphs/contributors) who participated in this project.
+See the list of [contributors](https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/graphs/contributors) who participated in this project.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ A restart of the `solgeneos` service will then activate the new monitors.
 1. Clone the git repo to the same directory (or download the zip and extract contents)   
     `git clone https://github.com/SolaceLabs/solace-custom-monitor-solgeneos`  
 1. Merge/replace the contents of the repo with the `solgeneossample` directory contents  
-    `cp solace-custom-monitor-solgeneos/build.* solgeneossample/`  
     `cp -r solace-custom-monitor-solgeneos/config solgeneossample/`  
     `cp -r solace-custom-monitor-solgeneos/src solgeneossample/`  
 1. Copy `httpclient` library supplied with `solgeneossample` to `bundledLib` directory  

--- a/src/com/solacesystems/solgeneos/custommonitors/MessageVPNLimitsMonitor.java
+++ b/src/com/solacesystems/solgeneos/custommonitors/MessageVPNLimitsMonitor.java
@@ -36,7 +36,7 @@ import com.solacesystems.solgeneos.solgeneosagent.monitor.View;
 public class MessageVPNLimitsMonitor extends BaseMonitor implements MonitorConstants {
   
 	// What version of the monitor?
-	static final public String MONITOR_VERSION = "1.0";
+	static final public String MONITOR_VERSION = "1.1";
 	
 	// The SEMP queries to execute:
     static final public String SHOW_VPN_DETAILS_REQUEST = 
@@ -333,6 +333,20 @@ public class MessageVPNLimitsMonitor extends BaseMonitor implements MonitorConst
 			
 			// Then use this merged columns information to set the final display order
 			this.setDesiredColumnOrder(currentColumnNames);
+		}
+		
+		// Have the broker limits been successfully initialized? Expected to be done in onPostInitialize() but double check before using it
+		if (this.brokerLimitsLookup == null) {
+			getLogger().error("Broker limits were not initialized in onPostInitialize(). Will attempt again now inside onCollect()");
+			
+			try {
+				this.setBrokerLimits();
+			}
+			catch (Exception e) {
+    			getLogger().error("An exception occurred during broker limits initialisation attempt inside onCollect(). " + e.getMessage());
+    			// Whatever is going wrong here, likely will affect remainder of onCollect() so just give up this run
+    			throw new Exception("Broker limits is failing to initialize, purposefully aborting onCollect()");
+			}
 		}
 		
 		// Merge the two responses, keyed on the vpn-name, into a combined table


### PR DESCRIPTION
**MessageVPNLimits Monitor:**
1. Hardened monitor for a scenario where the `brokerLimitsLookup` object fails to initialise on monitor startup. More specifically, if the `onPostInitialize()` call experienced an exception when doing the SEMP queries to determine broker limits.
(See Issue https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/issues/6)
2. Added a new log entry to better signal the above condition and the attempt to initialise broker limits again:
`ERROR [com.solacesystems.solgeneos.custommonitors.MessageVPNLimitsMonitor] Broker limits were not initialized in onPostInitialize(). Will attempt again now inside onCollect()`

**README:**
1. Correction of GitHub repository path in the step-by-step checkout instructions. Became incorrect after the repository underwent a rename and location change.