### PR TITLE
New monitors: ClientProfileLimits, ClientTopSubscribers. Plus minor fixes and enhancements.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -19,11 +19,17 @@ filenamepattern.topicendpoints.monitor=TopicEndpointsExMonitor
 jarname.vpnlimits.monitor=custommonitors-vpnlimits
 filenamepattern.vpnlimits.monitor=MessageVPNLimitsMonitor
 
+jarname.cplimits.monitor=custommonitors-clientprofilelimits
+filenamepattern.cplimits.monitor=ClientProfileLimitsMonitor
+
 jarname.messagerates.monitor=custommonitors-messagerates
 filenamepattern.messagerates.monitor=MessageRatesMonitor
 
 jarname.toppublishers.monitor=custommonitors-toppublishers
 filenamepattern.toppublishers.monitor=ClientsTopPublishersMonitor
+
+jarname.topsubscribers.monitor=custommonitors-topsubscribers
+filenamepattern.topsubscribers.monitor=ClientsTopSubscribersMonitor
 
 jarname.slowsubscribers.monitor=custommonitors-slowsubscribers
 filenamepattern.slowsubscribers.monitor=ClientsSlowSubscribersMonitor
@@ -63,6 +69,7 @@ scp.tracking.cachefile=scp-tracking.cache
 
 # dev appliance hostname for copying files to
 dev.appliance.hostname=192.168.31.50
+
 dev.appliance.user=support
 
 # deployment locations on appliance
@@ -70,4 +77,6 @@ deploy.monitor.jars.dir=/usr/sw/solgeneos/monitors
 deploy.monitor.configs.dir=/usr/sw/solgeneos/config
 
 # if being lazy (but not the most secure!) and avoiding user input step for scp task...
-#scp.pass=XXXX
+scp.pass=XXXX
+
+

--- a/build.properties
+++ b/build.properties
@@ -77,6 +77,6 @@ deploy.monitor.jars.dir=/usr/sw/solgeneos/monitors
 deploy.monitor.configs.dir=/usr/sw/solgeneos/config
 
 # if being lazy (but not the most secure!) and avoiding user input step for scp task...
-scp.pass=XXXX
+#scp.pass=XXXX
 
 

--- a/build.xml
+++ b/build.xml
@@ -45,7 +45,7 @@
 	<!-- compiles -->
     <target name="compile" depends="init">
     	<echo> Compiling...  </echo>
-
+		
 		<!-- Copy source to temp -->
     	<copy todir="${basedir}/${tempsrc.dir.name}">
     		<fileset dir="src">
@@ -55,7 +55,7 @@
 				</patternset>
 			</fileset>
     	</copy>
-
+		
         <javac  includeantruntime="false"
 				source="${compile.source}"
         		target="${compile.target}"
@@ -70,7 +70,7 @@
 	<!-- compiles advanced monitors -->
     <target name="compile-advanced" depends="init">
     	<echo> Compiling Advanced...  </echo>
-
+		
 		<!-- Copy source to temp -->
     	<copy todir="${basedir}/${tempsrc.dir.name}">
     		<fileset dir="src">
@@ -80,7 +80,7 @@
 				</patternset>
 			</fileset>
     	</copy>
-
+		
         <javac  includeantruntime="false"
 				source="${compile.source}"
         		target="${compile.target}"
@@ -91,7 +91,7 @@
             <classpath refid="project.classpath"/>
         </javac>
     </target>
-
+	
 	<!-- cleans -->
 	<target name="clean" depends="readProperties" description="Clean output">
 		<delete dir="${basedir}/${dist.dir.name}"/>
@@ -107,28 +107,28 @@
 			<fileset dir="${basedir}/${output.dir.name}">
 				<include name="**/util/*.class"/>
 			</fileset>
-		</jar>
+		</jar>	
 		<!-- Users Monitor Jar: -->
 		<echo>create ${jarname.users.monitor}.jar in ${dist.dir.name}</echo>
 		<jar destfile="${basedir}/${dist.dir.name}/lib/${jarname.users.monitor}.jar">
 			<fileset dir="${basedir}/${output.dir.name}">
 				<include name="**/${filenamepattern.users.monitor}*.class"/>
 			</fileset>
-		</jar>
+		</jar>		
 		<!-- QueuesEx Monitor Jar: -->
 		<echo>create ${jarname.queues.monitor}.jar in ${dist.dir.name}</echo>
 		<jar destfile="${basedir}/${dist.dir.name}/lib/${jarname.queues.monitor}.jar">
 			<fileset dir="${basedir}/${output.dir.name}">
 				<include name="**/${filenamepattern.queues.monitor}*.class"/>
 			</fileset>
-		</jar>
+		</jar>	
 		<!-- TopicEndpointsEx Monitor Jar: -->
 		<echo>create ${jarname.topicendpoints.monitor}.jar in ${dist.dir.name}</echo>
 		<jar destfile="${basedir}/${dist.dir.name}/lib/${jarname.topicendpoints.monitor}.jar">
 			<fileset dir="${basedir}/${output.dir.name}">
 				<include name="**/${filenamepattern.topicendpoints.monitor}*.class"/>
 			</fileset>
-		</jar>
+		</jar>			
 		<!-- MessageVPNLimits Monitor Jar: -->
 		<echo>create ${jarname.vpnlimits.monitor}.jar in ${dist.dir.name}</echo>
 		<jar destfile="${basedir}/${dist.dir.name}/lib/${jarname.vpnlimits.monitor}.jar">
@@ -136,6 +136,13 @@
 				<include name="**/${filenamepattern.vpnlimits.monitor}*.class"/>
 			</fileset>
 		</jar>
+		<!-- ClientProfileLimits Monitor Jar: -->
+		<echo>create ${jarname.cplimits.monitor}.jar in ${dist.dir.name}</echo>
+		<jar destfile="${basedir}/${dist.dir.name}/lib/${jarname.cplimits.monitor}.jar">
+			<fileset dir="${basedir}/${output.dir.name}">
+				<include name="**/${filenamepattern.cplimits.monitor}*.class"/>
+			</fileset>
+		</jar>		
 		<!-- MessageRates Monitor Jar: -->
 		<echo>create ${jarname.messagerates.monitor}.jar in ${dist.dir.name}</echo>
 		<jar destfile="${basedir}/${dist.dir.name}/lib/${jarname.messagerates.monitor}.jar">
@@ -150,13 +157,20 @@
 				<include name="**/${filenamepattern.toppublishers.monitor}*.class"/>
 			</fileset>
 		</jar>
+		<!-- ClientsTopSubscribers Monitor Jar: -->
+		<echo>create ${jarname.topsubscribers.monitor}.jar in ${dist.dir.name}</echo>
+		<jar destfile="${basedir}/${dist.dir.name}/lib/${jarname.topsubscribers.monitor}.jar">
+			<fileset dir="${basedir}/${output.dir.name}">
+				<include name="**/${filenamepattern.topsubscribers.monitor}*.class"/>
+			</fileset>
+		</jar>		
 		<!-- ClientsSlowSubscribers Monitor Jar: -->
 		<echo>create ${jarname.slowsubscribers.monitor}.jar in ${dist.dir.name}</echo>
 		<jar destfile="${basedir}/${dist.dir.name}/lib/${jarname.slowsubscribers.monitor}.jar">
 			<fileset dir="${basedir}/${output.dir.name}">
 				<include name="**/${filenamepattern.slowsubscribers.monitor}*.class"/>
 			</fileset>
-		</jar>
+		</jar>				
 		<!-- SoftwareSystemHealth Monitor Jar: -->
 		<echo>create ${jarname.softwaresystemhealth.monitor}.jar in ${dist.dir.name}</echo>
 		<jar destfile="${basedir}/${dist.dir.name}/lib/${jarname.softwaresystemhealth.monitor}.jar">
@@ -164,13 +178,12 @@
 				<include name="**/${filenamepattern.softwaresystemhealth.monitor}*.class"/>
 			</fileset>
 		</jar>			
-
 		<chmod perm="755">
 			<fileset dir="${basedir}/${dist.dir.name}/config"/>
 			<fileset dir="${basedir}/${dist.dir.name}/lib"/>
 		</chmod>
 	</target>
-
+	
 	<!-- build advanced -->
 		<target name="build-advanced" depends="compile-advanced" description="Build advanced monitor jars">
 			<echo>create ${jarname.messagingtester}.jar in ${dist.dir.name}</echo>
@@ -178,20 +191,20 @@
 				<fileset dir="${basedir}/${output.dir.name}">
 					<include name="**/messaging/*.class"/>
 				</fileset>
-			</jar>
+			</jar>	
 			<!-- MessagingTest Monitor Jar: -->
 			<echo>create ${jarname.messagingtest.monitor}.jar in ${dist.dir.name}</echo>
 			<jar destfile="${basedir}/${dist.dir.name}/lib/${jarname.messagingtest.monitor}.jar">
 				<fileset dir="${basedir}/${output.dir.name}">
 					<include name="**/${filenamepattern.messagingtest.monitor}*.class"/>
 				</fileset>
-			</jar>
+			</jar>	
 			<chmod perm="755">
 				<fileset dir="${basedir}/${dist.dir.name}/config"/>
 				<fileset dir="${basedir}/${dist.dir.name}/lib"/>
 			</chmod>
 		</target>
-
+	
 
 	<!-- clean build for distribution -->
 	<target name="dist" depends="clean, build" description="Clean output and then build monitor jars">
@@ -200,15 +213,15 @@
 	<!-- clean build for advanced distribution -->
 	<target name="dist-advanced" depends="clean, build, build-advanced" description="Clean output and then build monitor jars, including advanced ones">
 	</target>
-
+		
 	<!-- copy the changed libs and configs to dev appliance -->
 	<!-- task depends on jsch-0.1.55.jar being available in ant/lib -->
 	<target name="deploy" depends="readProperties" description="Copy monitor jars to dev appliance">
-
+	
 		<input message="Please enter the password for ${dev.appliance.user} user:" addproperty="scp.pass">
 			<handler classname="org.apache.tools.ant.input.SecureInputHandler" />
 		</input>
-
+		
 		<echo>Copying modified jar files from ${basedir}/${dist.dir.name}/lib to dev appliance</echo>
 		<scp todir="${dev.appliance.user}@${dev.appliance.hostname}:${deploy.monitor.jars.dir}" trust="true" sftp="true" password="${scp.pass}">
 			<fileset dir="${basedir}/${dist.dir.name}/lib">
@@ -218,7 +231,7 @@
 				</modified>
 			</fileset>
 		</scp>
-
+		
 		<echo>Copying modified config files from ${basedir}/${dist.dir.name}/config to dev appliance</echo>
 		<scp todir="${dev.appliance.user}@${dev.appliance.hostname}:${deploy.monitor.configs.dir}" trust="true" sftp="true" password="${scp.pass}">
 			<fileset dir="${basedir}/${dist.dir.name}/config">
@@ -229,13 +242,13 @@
 			</fileset>
 		</scp>
 	</target>
-
+	
 	<target name="deploy-advanced" depends="readProperties" description="Copy advanced monitor jars to dev appliance">
-
+	
 		<input message="Please enter the password for ${dev.appliance.user} user:" addproperty="scp.pass">
 			<handler classname="org.apache.tools.ant.input.SecureInputHandler" />
 		</input>
-
+		
 		<echo>Copying modified jar files from ${basedir}/${dist.dir.name}/lib to dev appliance</echo>
 		<scp todir="${dev.appliance.user}@${dev.appliance.hostname}:${deploy.monitor.jars.dir}" trust="true" sftp="true" password="${scp.pass}">
 			<fileset dir="${basedir}/${dist.dir.name}/lib">
@@ -245,7 +258,7 @@
 				</modified>
 			</fileset>
 		</scp>
-
+		
 		<echo>Copying modified config files from ${basedir}/${dist.dir.name}/config/advanced to dev appliance</echo>
 		<scp todir="${dev.appliance.user}@${dev.appliance.hostname}:${deploy.monitor.configs.dir}" trust="true" sftp="true" password="${scp.pass}">
 			<fileset dir="${basedir}/${dist.dir.name}/config/advanced">

--- a/config/ClientProfileLimitsMonitor.properties
+++ b/config/ClientProfileLimitsMonitor.properties
@@ -1,0 +1,12 @@
+#### monitor properties
+# monitor class name
+monitorClassName=com.solacesystems.solgeneos.custommonitors.ClientProfileLimitsMonitor
+
+# monitor sampling rate
+samplingRate=30
+# auto start
+autoStart=true
+
+#### view definition
+# view name
+view.v0.viewName=ClientProfileLimits

--- a/config/ClientsTopSubscribersMonitor.properties
+++ b/config/ClientsTopSubscribersMonitor.properties
@@ -1,0 +1,12 @@
+#### monitor properties
+# monitor class name
+monitorClassName=com.solacesystems.solgeneos.custommonitors.ClientsTopSubscribersMonitor
+
+# monitor sampling rate
+samplingRate=60
+# auto start
+autoStart=true
+
+#### view definition
+# view name
+view.v0.viewName=ClientsTopSubscribers

--- a/config/_user_ClientProfileLimitsMonitor.properties
+++ b/config/_user_ClientProfileLimitsMonitor.properties
@@ -1,0 +1,3 @@
+### Properties to control how this monitor behaves. 
+maxrows=100
+

--- a/geneos-rules/Geneos Rules Group - Custom Monitors v1.0.0 - XML.xml
+++ b/geneos-rules/Geneos Rules Group - Custom Monitors v1.0.0 - XML.xml
@@ -1,5 +1,5 @@
 <ruleGroup name="Custom Monitors v1-0-0">
-    <!-- Rule samples from https://github.com/SolaceLabs/solgeneos-custom-monitors/ -->
+    <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
     <rule name="Last Sample Time">
         <targets>
             <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview/headlines/cell[(@name=&quot;Last Sample Time&quot;)]</target>
@@ -35,7 +35,7 @@
         </block>
     </rule>
     <ruleGroup name="BrokerLimits">
-        <!-- Rule samples from https://github.com/SolaceLabs/solgeneos-custom-monitors/ -->
+        <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
         <rule name="Allocated Limit">
             <targets>
                 <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview/rows/row/cell[(@column=&quot;Allocated Limit&quot;)]</target>
@@ -273,8 +273,485 @@
             </block>
         </rule>
     </ruleGroup>
+    <ruleGroup name="ClientProfileLimits">
+        <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
+        <rule name="Connections">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row[wild(@name,&quot;*&quot;)]/cell[(@column=&quot;Connections - Current&quot;)]</target>
+            </targets>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Max Configured">../cell[(@column=&quot;Connections - Max&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- Rule to check the current usage against the profile maximum configured limit-->
+                <!-- Currently looking at all rows, i.e. all profiles. Can replace the wildcard * with a VPN name for more targeted rule application for individual teams-->
+                <set>
+                    <var ref="max_configured"></var>
+                    <dataItem>
+                        <pathAlias ref="Max Configured"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <set>
+                    <var ref="high_threshold"></var>
+                    <integer>65</integer>
+                </set>
+                <set>
+                    <var ref="exceed_threshold"></var>
+                    <integer>80</integer>
+                </set>
+                <set>
+                    <var ref="value"></var>
+                    <multiply>
+                        <divide>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                            <var ref="max_configured"></var>
+                        </divide>
+                        <integer>100</integer>
+                    </multiply>
+                </set>
+                <if>
+                    <and>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <equal>
+                            <dataItem>
+                                <property>state/@severity</property>
+                            </dataItem>
+                            <severity>undefined</severity>
+                        </equal>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>state/@severity</property>
+                            <severity>ok</severity>
+                        </update>
+                    </transaction>
+                    <if>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <transaction>
+                            <delay>300</delay>
+                            <update>
+                                <property>state/@severity</property>
+                                <severity>ok</severity>
+                            </update>
+                        </transaction>
+                        <if>
+                            <and>
+                                <and>
+                                    <gte>
+                                        <var ref="value"></var>
+                                        <var ref="high_threshold"></var>
+                                    </gte>
+                                    <lte>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </lte>
+                                </and>
+                                <notEqual>
+                                    <dataItem>
+                                        <property>state/@severity</property>
+                                    </dataItem>
+                                    <severity>warning</severity>
+                                </notEqual>
+                            </and>
+                            <transaction>
+                                <update>
+                                    <property>state/@severity</property>
+                                    <severity>warning</severity>
+                                </update>
+                            </transaction>
+                            <if>
+                                <and>
+                                    <gt>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </gt>
+                                    <notEqual>
+                                        <dataItem>
+                                            <property>state/@severity</property>
+                                        </dataItem>
+                                        <severity>critical</severity>
+                                    </notEqual>
+                                </and>
+                                <transaction>
+                                    <update>
+                                        <property>state/@severity</property>
+                                        <severity>critical</severity>
+                                    </update>
+                                </transaction>
+                            </if>
+                        </if>
+                    </if>
+                </if>
+            </block>
+        </rule>
+        <rule name="Subscriptions">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row[wild(@name,&quot;*&quot;)]/cell[(@column=&quot;Subscriptions - Current&quot;)]</target>
+            </targets>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Max Configured">../cell[(@column=&quot;Subscriptions - Max&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- Rule to check the current usage against the profile maximum configured limit-->
+                <!-- Currently looking at all rows, i.e. all VPNs. Can replace the wildcard * with a VPN name for more targeted rule application for individual teams-->
+                <set>
+                    <var ref="max_configured"></var>
+                    <dataItem>
+                        <pathAlias ref="Max Configured"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <set>
+                    <var ref="high_threshold"></var>
+                    <integer>65</integer>
+                </set>
+                <set>
+                    <var ref="exceed_threshold"></var>
+                    <integer>80</integer>
+                </set>
+                <set>
+                    <var ref="value"></var>
+                    <multiply>
+                        <divide>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                            <var ref="max_configured"></var>
+                        </divide>
+                        <integer>100</integer>
+                    </multiply>
+                </set>
+                <if>
+                    <and>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <equal>
+                            <dataItem>
+                                <property>state/@severity</property>
+                            </dataItem>
+                            <severity>undefined</severity>
+                        </equal>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>state/@severity</property>
+                            <severity>ok</severity>
+                        </update>
+                    </transaction>
+                    <if>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <transaction>
+                            <delay>300</delay>
+                            <update>
+                                <property>state/@severity</property>
+                                <severity>ok</severity>
+                            </update>
+                        </transaction>
+                        <if>
+                            <and>
+                                <and>
+                                    <gte>
+                                        <var ref="value"></var>
+                                        <var ref="high_threshold"></var>
+                                    </gte>
+                                    <lte>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </lte>
+                                </and>
+                                <notEqual>
+                                    <dataItem>
+                                        <property>state/@severity</property>
+                                    </dataItem>
+                                    <severity>warning</severity>
+                                </notEqual>
+                            </and>
+                            <transaction>
+                                <update>
+                                    <property>state/@severity</property>
+                                    <severity>warning</severity>
+                                </update>
+                            </transaction>
+                            <if>
+                                <and>
+                                    <gt>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </gt>
+                                    <notEqual>
+                                        <dataItem>
+                                            <property>state/@severity</property>
+                                        </dataItem>
+                                        <severity>critical</severity>
+                                    </notEqual>
+                                </and>
+                                <transaction>
+                                    <update>
+                                        <property>state/@severity</property>
+                                        <severity>critical</severity>
+                                    </update>
+                                </transaction>
+                            </if>
+                        </if>
+                    </if>
+                </if>
+            </block>
+        </rule>
+        <rule name="Ingress Flows">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row/cell[(@column=&quot;Ingress Flows - Current&quot;)]</target>
+            </targets>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Max Configured">../cell[(@column=&quot;Ingress Flows - Max&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- Rule to check the current usage against the profile maximum configured limit-->
+                <set>
+                    <var ref="max_configured"></var>
+                    <dataItem>
+                        <pathAlias ref="Max Configured"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <set>
+                    <var ref="high_threshold"></var>
+                    <integer>65</integer>
+                </set>
+                <set>
+                    <var ref="exceed_threshold"></var>
+                    <integer>80</integer>
+                </set>
+                <set>
+                    <var ref="value"></var>
+                    <multiply>
+                        <divide>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                            <var ref="max_configured"></var>
+                        </divide>
+                        <integer>100</integer>
+                    </multiply>
+                </set>
+                <if>
+                    <and>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <equal>
+                            <dataItem>
+                                <property>state/@severity</property>
+                            </dataItem>
+                            <severity>undefined</severity>
+                        </equal>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>state/@severity</property>
+                            <severity>ok</severity>
+                        </update>
+                    </transaction>
+                    <if>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <transaction>
+                            <delay>300</delay>
+                            <update>
+                                <property>state/@severity</property>
+                                <severity>ok</severity>
+                            </update>
+                        </transaction>
+                        <if>
+                            <and>
+                                <and>
+                                    <gte>
+                                        <var ref="value"></var>
+                                        <var ref="high_threshold"></var>
+                                    </gte>
+                                    <lte>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </lte>
+                                </and>
+                                <notEqual>
+                                    <dataItem>
+                                        <property>state/@severity</property>
+                                    </dataItem>
+                                    <severity>warning</severity>
+                                </notEqual>
+                            </and>
+                            <transaction>
+                                <update>
+                                    <property>state/@severity</property>
+                                    <severity>warning</severity>
+                                </update>
+                            </transaction>
+                            <if>
+                                <and>
+                                    <gt>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </gt>
+                                    <notEqual>
+                                        <dataItem>
+                                            <property>state/@severity</property>
+                                        </dataItem>
+                                        <severity>critical</severity>
+                                    </notEqual>
+                                </and>
+                                <transaction>
+                                    <update>
+                                        <property>state/@severity</property>
+                                        <severity>critical</severity>
+                                    </update>
+                                </transaction>
+                            </if>
+                        </if>
+                    </if>
+                </if>
+            </block>
+        </rule>
+        <rule name="Egress Flows">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row/cell[(@column=&quot;Egress Flows - Current&quot;)]</target>
+            </targets>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Max Configured">../cell[(@column=&quot;Egress Flows - Max&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- Rule to check the current usage against the profile maximum configured limit-->
+                <set>
+                    <var ref="max_configured"></var>
+                    <dataItem>
+                        <pathAlias ref="Max Configured"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <set>
+                    <var ref="high_threshold"></var>
+                    <integer>65</integer>
+                </set>
+                <set>
+                    <var ref="exceed_threshold"></var>
+                    <integer>80</integer>
+                </set>
+                <set>
+                    <var ref="value"></var>
+                    <multiply>
+                        <divide>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                            <var ref="max_configured"></var>
+                        </divide>
+                        <integer>100</integer>
+                    </multiply>
+                </set>
+                <if>
+                    <and>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <equal>
+                            <dataItem>
+                                <property>state/@severity</property>
+                            </dataItem>
+                            <severity>undefined</severity>
+                        </equal>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>state/@severity</property>
+                            <severity>ok</severity>
+                        </update>
+                    </transaction>
+                    <if>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <transaction>
+                            <delay>300</delay>
+                            <update>
+                                <property>state/@severity</property>
+                                <severity>ok</severity>
+                            </update>
+                        </transaction>
+                        <if>
+                            <and>
+                                <and>
+                                    <gte>
+                                        <var ref="value"></var>
+                                        <var ref="high_threshold"></var>
+                                    </gte>
+                                    <lte>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </lte>
+                                </and>
+                                <notEqual>
+                                    <dataItem>
+                                        <property>state/@severity</property>
+                                    </dataItem>
+                                    <severity>warning</severity>
+                                </notEqual>
+                            </and>
+                            <transaction>
+                                <update>
+                                    <property>state/@severity</property>
+                                    <severity>warning</severity>
+                                </update>
+                            </transaction>
+                            <if>
+                                <and>
+                                    <gt>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </gt>
+                                    <notEqual>
+                                        <dataItem>
+                                            <property>state/@severity</property>
+                                        </dataItem>
+                                        <severity>critical</severity>
+                                    </notEqual>
+                                </and>
+                                <transaction>
+                                    <update>
+                                        <property>state/@severity</property>
+                                        <severity>critical</severity>
+                                    </update>
+                                </transaction>
+                            </if>
+                        </if>
+                    </if>
+                </if>
+            </block>
+        </rule>
+    </ruleGroup>
     <ruleGroup name="MessageVPNLimits">
-        <!-- Rule samples from https://github.com/SolaceLabs/solgeneos-custom-monitors/ -->
+        <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
         <rule name="Connections SMF">
             <targets>
                 <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;MessageVPNLimits&quot;)]/rows/row[wild(@name,&quot;*&quot;)]/cell[(@column=&quot;Connections (SMF) - Current&quot;)]</target>
@@ -1223,7 +1700,7 @@
         </rule>
     </ruleGroup>
     <ruleGroup name="QueuesEx">
-        <!-- Rule samples from https://github.com/SolaceLabs/solgeneos-custom-monitors/ -->
+        <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
         <rule name="Spool Usage">
             <targets>
                 <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;QueuesEx&quot;)]/rows/row/cell[(@column=&quot;Spool Usage (MB)&quot;)]</target>
@@ -1620,7 +2097,7 @@
         </rule>
     </ruleGroup>
     <ruleGroup name="TopicEndpointsEx">
-        <!-- Rule samples from https://github.com/SolaceLabs/solgeneos-custom-monitors/ -->
+        <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
         <rule name="Spool Usage">
             <targets>
                 <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;TopicEndpointsEx&quot;)]/rows/row/cell[(@column=&quot;Spool Usage (MB)&quot;)]</target>
@@ -1971,7 +2448,7 @@
         </rule>
     </ruleGroup>
     <ruleGroup name="ClientsSlowSubscribers">
-        <!-- Rule samples from https://github.com/SolaceLabs/solgeneos-custom-monitors/ -->
+        <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
         <rule name="Slow Subscriber Count">
             <targets>
                 <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientsSlowSubscribers&quot;)]/headlines/cell[(@name=&quot;Number of Slow Subscribers&quot;)]</target>
@@ -2003,7 +2480,7 @@
         </rule>
     </ruleGroup>
     <ruleGroup name="MessagingTester">
-        <!-- Rule samples from https://github.com/SolaceLabs/solgeneos-custom-monitors/ -->
+        <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
         <rule name="Monitor Status">
             <targets>
                 <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;MessagingTester&quot;)]/headlines/cell[(@name=&quot;Monitor Status&quot;)]</target>
@@ -2203,7 +2680,7 @@
         </rule>
     </ruleGroup>
     <ruleGroup name="MessageRatesHWM">
-        <!-- Rule samples from https://github.com/SolaceLabs/solgeneos-custom-monitors/ -->
+        <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
         <rule name="Current Msg Rate">
             <targets>
                 <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;MessageRatesHWM&quot;)]/rows/row[wild(@name,&quot;Current Msg Rate*&quot;)]/cell[(@column=&quot;Current Msg Rate&quot;)]</target>

--- a/src/com/solacesystems/solgeneos/custommonitors/ClientProfileLimitsMonitor.java
+++ b/src/com/solacesystems/solgeneos/custommonitors/ClientProfileLimitsMonitor.java
@@ -1,0 +1,412 @@
+package com.solacesystems.solgeneos.custommonitors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.Vector;
+import java.util.stream.Collectors;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.HttpParams;
+import com.solacesystems.solgeneos.custommonitors.util.MonitorConstants;
+import com.solacesystems.solgeneos.custommonitors.util.MultiFieldSEMPParser;
+import com.solacesystems.solgeneos.custommonitors.util.SampleHttpSEMPResponse;
+import com.solacesystems.solgeneos.custommonitors.util.SampleResponseHandler;
+import com.solacesystems.solgeneos.custommonitors.util.SampleSEMPParser;
+import com.solacesystems.solgeneos.custommonitors.util.TargetedMultiRecordSEMPParser;
+import com.solacesystems.solgeneos.custommonitors.util.VPNRecordSEMPParser;
+import com.solacesystems.solgeneos.solgeneosagent.SolGeneosAgent;
+import com.solacesystems.solgeneos.solgeneosagent.UserPropertiesConfig;
+import com.solacesystems.solgeneos.solgeneosagent.monitor.BaseMonitor;
+import com.solacesystems.solgeneos.solgeneosagent.monitor.View;
+
+public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorConstants {
+  
+	// What version of the monitor?
+	static final public String MONITOR_VERSION = "1.0.0";
+	
+	// The SEMP queries to execute:
+    static final public String SHOW_CP_DETAILS_REQUEST = 
+            "<rpc>" + 
+            "	<show>" +
+            "		<client-profile>" +
+            "			<name>*</name>" +
+            "			<detail></detail>" +
+            "		</client-profile>" +
+            "	</show>" +
+            "</rpc>";
+    
+    static final public String SHOW_CLIENT_DETAILS_REQUEST = 
+            "<rpc>" + 
+            "	<show>" +
+            "		<client>" +
+            "			<name>*</name>" +
+            "			<detail></detail>" +
+            "		</client>" +
+            "	</show>" +
+            "</rpc>";
+    
+    // The elements of interest/exclusion within the Client Profile Details SEMP response processing:
+    static final private String CP_DETAILS_RESPONSE_ELEMENT_NAME_ROWS = "profile";
+    static final private  List<String> CP_DETAILS_RESPONSE_COLUMNS = 
+    		Arrays.asList("RowUID", "name", "message-vpn", "maximum-transacted-sessions", "maximum-transactions", "maximum-endpoints-per-client-username",
+    				"maximum-egress-flows", "maximum-ingress-flows", "max-connections-per-client-username", "num-users", "max-subscriptions");
+    static final private  List<String> CP_DETAILS_RESPONSE_ELEMENT_NAMES_IGNORE = Arrays.asList("profile-users", "tcp", "ssl", "compression", "event-configuration");
+    
+    // The elements of interest/exclusion within the Client Details SEMP response processing:
+    static final private String CLIENT_DETAILS_RESPONSE_ELEMENT_NAME_ROWS = "client";
+    static final private  List<String> CLIENT_DETAILS_RESPONSE_COLUMNS = 
+    		Arrays.asList("RowUID", "name", "message-vpn", "profile", "num-subscriptions", "total-ingress-flows", "total-egress-flows");
+    static final private  List<String> CLIENT_DETAILS_RESPONSE_ELEMENT_NAMES_IGNORE = Arrays.asList("event-configuration");
+    
+    // What should be the formatting style?
+    static final private String FLOAT_FORMAT_STYLE = "%.0f";	// 0 decimal places. Wanted to add thousandth separator but Geneos fails to recognise it as numbers for rule purposes!
+        
+    // What is the desired order of columns?
+    private List<Integer> desiredColumnOrder;
+    
+    // Override the column names to more human friendly
+    static final private List<String> CP_LIMITS_DATAVIEW_COLUMN_NAMES = 
+    		Arrays.asList("RowUID", "Client Profile", "Message VPN", 
+    				"Subscriptions - Current", "Subscriptions - Max",
+    				"Connections - Current", "Connections - Max", 
+    				"Ingress Flows - Current", "Ingress Flows - Max",
+    				"Egress Flows - Current", "Egress Flows - Max", 
+    				"Queue and TEs - Max",
+    				"Transactions - Max",
+    				"Transacted Sessions - Max",
+    				"Number of Users",
+    				"Utilisation Score"
+    				);
+    
+    static final String[] RESOURCES = {"Subscriptions", "Connections", "Egress Flows", "Ingress Flows"};
+    
+    private DefaultHttpClient httpClient;
+    private ResponseHandler<SampleHttpSEMPResponse> responseHandler;
+    private TargetedMultiRecordSEMPParser multiRecordParserClientProfile;
+    private TargetedMultiRecordSEMPParser multiRecordParserClientDetail;
+    
+    private LinkedHashMap<String, Object> globalHeadlines = new LinkedHashMap<String, Object>();
+    // Is the monitor creating a dataview per VPN or everything is in one view?
+    // What is the maximum number of rows to limit the dataview to? Default 200 unless overridden.
+    private int maxRows = 200;
+
+    // When sorting the table rows before limiting to maxrows, how to prioritise the top of the cut?
+    // This comparator is used to sort the table so the highest utilisation score is at the top of the table
+    // Note: Assuming the sort is done after columns re-ordered and computed columns added. So use lookup via COLUMN_NAME_OVERRIDE
+    static class UtilisationComparator implements Comparator<Object>
+    {
+        @SuppressWarnings("unchecked")
+		public int compare(Object tableRow1, Object tableRow2)
+        {
+        	int value1 = Integer.parseInt( ((ArrayList<String>)tableRow1).get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Utilisation Score") ));
+        	int value2 = Integer.parseInt( ((ArrayList<String>)tableRow2).get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Utilisation Score") ));
+
+            return Double.compare(value2, value1);	
+        }
+    }
+    
+    /**
+     * This method is called after initialisation but before the monitor is started.
+     * 
+     * It is a good place to initialise any instance variables.
+     */
+	@Override
+	protected void onPostInitialize() throws Exception {
+		// use logger provided by the BaseMonitor class
+		if (getLogger().isInfoEnabled()) {
+			getLogger().info("Initializing http client");
+		}
+		
+		
+		// Setup global headlines once to use on each onCollect()
+		
+		// (1) Are there global headlines to apply to the views created by this monitor?
+		UserPropertiesConfig globalHeadlinesPropsConfig = SolGeneosAgent.onlyInstance.
+				getUserPropertiesConfig(GLOBAL_HEADLINES_PROPERTIES_FILE_NAME);
+		// If the file exists and its not empty, add each property as a headline:
+		if (globalHeadlinesPropsConfig != null && globalHeadlinesPropsConfig.getProperties() != null) {
+			globalHeadlinesPropsConfig.getProperties().forEach((key, value) -> globalHeadlines.put(key.toString() , value.toString()));
+		}
+		
+		// (2) Add this monitor's important details as headlines
+		globalHeadlines.put("Custom Monitor", this.getName() + " v" + MONITOR_VERSION);
+		globalHeadlines.put("Sampling Interval (secs)", this.getSamplingRate());		
+
+		// (3) Are there properties specific to this monitor in its config file?
+		// This monitor can be operated in two modes: (1) single view, or (2) multi view.
+		// In single view, all the profiles are listed in the same dataview. In multi view mode, profiles are reported in per-VPN dataviews
+		
+		UserPropertiesConfig monitorPropsConfig = SolGeneosAgent.onlyInstance.
+				getUserPropertiesConfig(MONITOR_PROPERTIES_FILE_NAME_PREFIX + this.getName() +MONITOR_PROPERTIES_FILE_NAME_SUFFIX);
+		// If the file exists and its not empty, add each property as a headline:
+		if (monitorPropsConfig != null && monitorPropsConfig.getProperties() != null) {
+			maxRows = Integer.parseInt(monitorPropsConfig.getProperties().get("maxrows").toString());
+		}
+		globalHeadlines.put("Maximum rows to display", maxRows);
+		
+		
+		// (4) Retrieve SEMP over HTTP properties from global properties
+		Properties props = SolGeneosAgent.onlyInstance.getGlobalProperties();
+        String host = props.getProperty(MGMT_IP_ADDRESS_PROPERTY_NAME);
+        int port = 80;
+        try {
+        	port = Integer.parseInt(props.getProperty(MGMT_PORT_PROPERTY_NAME));
+        } catch (NumberFormatException e) {
+    		if (getLogger().isInfoEnabled()) {
+    			getLogger().info("Invalid port number, using default 80");
+    		}
+        }
+        String username = props.getProperty(MGMT_USERNAME_PROPERTY_NAME);
+        String password = SolGeneosAgent.onlyInstance.getEncryptedProperty(MGMT_ENCRYPTED_PASSWORD_PROPERTY_NAME,MGMT_PASSWORD_PROPERTY_NAME);
+		
+		// create a http client
+		httpClient = new DefaultHttpClient();
+		HttpParams httpParams = httpClient.getParams();
+				
+		// set connection target
+	    HttpHost target = new HttpHost(host, port);
+	    httpParams.setParameter(ClientPNames.DEFAULT_HOST, target);
+        
+        // set connection credential
+	    httpClient.getCredentialsProvider().setCredentials(
+	    		new AuthScope(host, port),
+                new UsernamePasswordCredentials(username, password));
+	    
+	    // response handler used http client to process http response and release
+	    // associated resources
+        responseHandler = new SampleResponseHandler();
+        
+        // create SEMP parser with the name of the element that contains the records
+		multiRecordParserClientProfile = new TargetedMultiRecordSEMPParser(CP_DETAILS_RESPONSE_ELEMENT_NAME_ROWS, CP_DETAILS_RESPONSE_COLUMNS, CP_DETAILS_RESPONSE_ELEMENT_NAMES_IGNORE);
+		multiRecordParserClientDetail = new TargetedMultiRecordSEMPParser(CLIENT_DETAILS_RESPONSE_ELEMENT_NAME_ROWS, CLIENT_DETAILS_RESPONSE_COLUMNS, CLIENT_DETAILS_RESPONSE_ELEMENT_NAMES_IGNORE);
+		
+	}
+	
+	private void setDesiredColumnOrder (List<String> currentColumnNames) {
+	    
+		desiredColumnOrder = Arrays.asList(
+			currentColumnNames.indexOf("RowUID"), currentColumnNames.indexOf("name"), currentColumnNames.indexOf("message-vpn"),  
+    		currentColumnNames.indexOf("max-subscriptions"), 
+    		currentColumnNames.indexOf("max-connections-per-client-username"),
+    		currentColumnNames.indexOf("maximum-ingress-flows"),
+    		currentColumnNames.indexOf("maximum-egress-flows"),
+    		currentColumnNames.indexOf("maximum-endpoints-per-client-username"), 
+    		currentColumnNames.indexOf("maximum-transactions"),
+    		currentColumnNames.indexOf("maximum-transacted-sessions"), 
+    		currentColumnNames.indexOf("num-users")
+		);
+	}
+	
+	private void submitSEMPQuery (String sempQuery, SampleSEMPParser sempParser) throws Exception {
+		
+		// Get the first SEMP query response...
+		HttpPost post = new HttpPost(HTTP_REQUEST_URI);
+		post.setHeader(HEADER_CONTENT_TYPE_UTF8);
+		post.setEntity(new ByteArrayEntity(sempQuery.getBytes("UTF-8")));
+		
+		
+		SampleHttpSEMPResponse resp = httpClient.execute(post, responseHandler);
+        if (resp.getStatusCode() != 200) {
+        	throw new Exception("Error occurred while sending request: " + resp.getStatusCode() 
+        			+ " - " + resp.getReasonPhrase());
+        }	        
+        String respBody = resp.getRespBody();        
+        sempParser.parse(respBody);
+	}
+    
+	/**
+	 * This method is responsible to collect data required for a view.
+	 * @return The next monitor state which should be State.REPORTING_QUEUE.
+	 */
+
+	@SuppressWarnings({ "unchecked", "static-access" })
+	@Override
+	protected State onCollect() throws Exception {
+
+		TreeMap<String, View> viewMap = getViewMap();
+		
+		LinkedHashMap<String, Object> headlines;
+		
+		// Get the first SEMP query response...
+		submitSEMPQuery(SHOW_CP_DETAILS_REQUEST, multiRecordParserClientProfile);
+		// Get the second SEMP query response...
+		submitSEMPQuery(SHOW_CLIENT_DETAILS_REQUEST, multiRecordParserClientDetail);
+		
+		// Has the desired column order been determined yet? (Done on the first time responses and their columns came back.)
+		if (this.desiredColumnOrder == null) {
+			// First get the column names from the VPN details response
+			List<String> currentColumnNames = multiRecordParserClientProfile.getColumnNames();
+			
+			// Then use this merged columns information to set the final display order
+			this.setDesiredColumnOrder(currentColumnNames);
+		}
+				
+		// Will take what is received as the table contents and then do further Java8 Streams based processing... 
+		Vector<Object> clientProfileData;
+		Vector<Object> clientProfileDataTemp;
+		ArrayList<String> tableRowClientProfile;
+		
+		Vector<Object> clientData;
+		ArrayList<String> tableRowClient;
+		
+		clientProfileData = multiRecordParserClientProfile.getTableContent();
+		clientData = multiRecordParserClientDetail.getTableContent();
+		List<String> clientDataColumnNames = multiRecordParserClientDetail.getColumnNames();
+		
+		// Reorder the merged table into the column order we want. 
+		clientProfileDataTemp = new Vector<Object>();
+		
+		// Iterate to each row in the table contents
+		for (int index = 0; index < clientProfileData.size(); index++) {
+			
+			// Build a new tableRow by adding to it in the right order 
+			ArrayList<String> tableRow = new ArrayList<String>();
+			
+			for (Integer columnNumber : this.desiredColumnOrder){
+				tableRow.add( ((ArrayList<String>)clientProfileData.get(index)).get(columnNumber));
+			}
+			
+			// Add the empty columns for computed values later on
+			tableRow.add(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Subscriptions - Current"), "");
+			tableRow.add(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Connections - Current"), "");
+			tableRow.add(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Ingress Flows - Current"), "");
+			tableRow.add(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Egress Flows - Current"), "");
+			
+			// Add the newly created row to temp
+			clientProfileDataTemp.add(tableRow); 
+		}  
+		
+		clientProfileData = clientProfileDataTemp;
+		
+		// From the table remove client profiles that begin with # as those are system managed
+		// Also remove the ones that have no configured username referencing it
+		// While iterating here, add the missing computed column values
+		
+		Iterator<Object> itr = clientProfileData.iterator();	
+		while (itr.hasNext()) {		
+			ArrayList<String> tempTableRow = (ArrayList<String>) itr.next();
+			String cpName = tempTableRow.get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Client Profile"));
+			String vpnName = tempTableRow.get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Message VPN"));
+			int userCount = Integer.parseInt(tempTableRow.get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Number of Users")));
+			
+			if (cpName.startsWith("#") || userCount == 0) {
+				itr.remove();
+			}
+			else
+			{	
+				// Only if a 1:1 mapping of client profiles to usernames, calculate the following:
+				// (Since limits are 'per-username', cannot easily display limit usage at each username referencing this profile)
+				if (userCount == 1) {
+					// How many connections present using this client profile?
+					long nConnections = 
+							clientData
+							.stream()
+							.filter(tableRow -> vpnName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("message-vpn") )   ))
+							.filter(tableRow -> cpName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("profile") )   ))
+							.count();	
+					tempTableRow.set(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Connections - Current"), Long.toString(nConnections));
+					
+					// How many subscriptions used by clients with this client profile?
+					long nSubscriptions = 
+							clientData
+							.stream()
+							.filter(tableRow -> vpnName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("message-vpn") )   ))
+							.filter(tableRow -> cpName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("profile") )   ))
+							.map   (tableRow -> ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("num-subscriptions")  ) )	// Only that one column)
+							.mapToLong(Long::parseLong)
+							.sum();	
+					tempTableRow.set(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Subscriptions - Current"), Long.toString(nSubscriptions));
+					
+					// How many ingress flows used by clients with this client profile?
+					long nIngressFlows = 
+							clientData
+							.stream()
+							.filter(tableRow -> vpnName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("message-vpn") )   ))
+							.filter(tableRow -> cpName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("profile") )   ))
+							.map   (tableRow -> ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("total-ingress-flows")  ) )	// Only that one column)
+							.mapToLong(Long::parseLong)
+							.sum();	
+					tempTableRow.set(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Ingress Flows - Current"), Long.toString(nIngressFlows));
+					
+					// How many egress flows used by clients with this client profile?
+					long nEgressFlows = 
+							clientData
+							.stream()
+							.filter(tableRow -> vpnName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("message-vpn") )   ))
+							.filter(tableRow -> cpName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("profile") )   ))
+							.map   (tableRow -> ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("total-egress-flows")  ) )	// Only that one column)
+							.mapToLong(Long::parseLong)
+							.sum();	
+					tempTableRow.set(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Egress Flows - Current"), Long.toString(nEgressFlows));
+				}
+
+				// Add a new utilisation score calculated column
+				double score = 0;
+				int nUnusedResource = 0;
+				for (String resourceName : RESOURCES) {
+					double current = 
+							tempTableRow.get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf(resourceName + " - Current")).isEmpty() ? 0 : Double.parseDouble(tempTableRow.get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf(resourceName + " - Current")));
+					double max = Double.parseDouble(tempTableRow.get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf(resourceName + " - Max")));
+					
+					if (max == 0) {
+						nUnusedResource++;
+					}
+					else {
+						score += current / max;
+					}
+				}
+				tempTableRow.add(String.format(FLOAT_FORMAT_STYLE, ((score / (RESOURCES.length - nUnusedResource) ) * 100 )) );
+			}
+		}  
+		
+		// Now calculate the headlines
+		headlines = new LinkedHashMap<String, Object>();
+		headlines.putAll(globalHeadlines);	
+		
+		String lastSampleTime = SolGeneosAgent.onlyInstance.getCurrentTimeString();
+		headlines.put("Last Sample Time", lastSampleTime);
+		
+		// Sort the list by the utilisation score. Then also limit to the max row count if exceeding it...
+		clientProfileDataTemp = new Vector<Object>();
+		
+		clientProfileDataTemp.addAll(
+				clientProfileData
+				.stream()
+				.sorted(new UtilisationComparator())	
+				.limit(maxRows)				// Then cut the rows at max limit
+				.collect(Collectors.toCollection(Vector<Object>::new))
+				);
+		clientProfileData = clientProfileDataTemp;
+
+		// Main table content all complete now for publishing. Just add the column names too.
+		clientProfileData.add(0, this.CP_LIMITS_DATAVIEW_COLUMN_NAMES);	// No longer as received from parser in receivedColumnNames
+				
+		// Now ready to publish tables to the view map
+    	if (viewMap != null && viewMap.size() > 0) {
+    		for (Iterator<String> viewIt = viewMap.keySet().iterator(); viewIt.hasNext();) 
+    		{
+    			View view = viewMap.get(viewIt.next());	
+    			if (view.isActive()) {
+					view.setHeadlines(headlines);
+    				view.setTableContent(clientProfileData);
+    			}
+    		}
+    	}
+        return State.REPORTING_QUEUE;
+	}
+}

--- a/src/com/solacesystems/solgeneos/custommonitors/ClientsTopSubscribersMonitor.java
+++ b/src/com/solacesystems/solgeneos/custommonitors/ClientsTopSubscribersMonitor.java
@@ -1,0 +1,211 @@
+package com.solacesystems.solgeneos.custommonitors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.Vector;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.HttpParams;
+import com.solacesystems.solgeneos.custommonitors.util.MonitorConstants;
+import com.solacesystems.solgeneos.custommonitors.util.MultiRecordSEMPParser;
+import com.solacesystems.solgeneos.custommonitors.util.SampleHttpSEMPResponse;
+import com.solacesystems.solgeneos.custommonitors.util.SampleResponseHandler;
+import com.solacesystems.solgeneos.custommonitors.util.SampleSEMPParser;
+import com.solacesystems.solgeneos.solgeneosagent.SolGeneosAgent;
+import com.solacesystems.solgeneos.solgeneosagent.UserPropertiesConfig;
+import com.solacesystems.solgeneos.solgeneosagent.monitor.BaseMonitor;
+import com.solacesystems.solgeneos.solgeneosagent.monitor.View;
+
+public class ClientsTopSubscribersMonitor extends BaseMonitor implements MonitorConstants {
+  
+	// What version of the monitor?
+	static final public String MONITOR_VERSION = "1.0";
+	
+	// The SEMP queries to execute:
+    static final public String SHOW_CLIENTS_REQUEST = 
+        "<rpc>" + 
+        "	<show>" +
+        "		<client>" +
+        "			<name>*</name>" +
+        "			<sorted-stats/>" +
+        "			<stats-to-show>current-egress-message-rate-per-second,average-egress-message-rate-per-minute,current-egress-byte-rate-per-second,average-egress-byte-rate-per-minute,total-client-bytes-sent</stats-to-show>" +
+        "			<sort-by/>" +
+        "			<stats-to-sort-by>average-egress-byte-rate-per-minute</stats-to-sort-by>" +
+        "			<count/>" +
+        "			<num-elements>10</num-elements>" +
+        "		</client>" +
+        "	</show>" +
+        "</rpc>";
+        
+    // The elements of interest/exclusion within the SEMP response processing:
+    static final private String CLIENT_DETAILS_RESPONSE_ELEMENT_NAME = "row";
+
+    // What should be the formatting style?
+    static final private String FLOAT_FORMAT_STYLE = "%.3f";	// 3 decimal places. Wanted to add thousandth separator but Geneos fails to recognise it as numbers for rule purposes!
+    
+    // Override the column names to more human friendly
+    static final private List<String> DATAVIEW_COLUMN_NAMES = 
+    		Arrays.asList("Client ID", "Username", "Message VPN", 
+    				"Current Egress Msg Rate", "Average Egress Msg Rate",
+    				"Current Egress MByte Rate", "Average Egress MByte Rate",
+    				"Total MBytes Sent");
+    
+    static final private List<String> COLUMNS_IN_MBYTES = Arrays.asList("Current Egress MByte Rate", "Total MBytes Sent", "Average Egress MByte Rate");
+    
+    
+    static final private int BYTE_TO_MBYTE = 1048576;
+    
+    private DefaultHttpClient httpClient;
+    private ResponseHandler<SampleHttpSEMPResponse> responseHandler;
+    private MultiRecordSEMPParser multiRecordParser;
+
+    private Vector<Object> tableContent;
+    private LinkedHashMap<String, Object> globalHeadlines = new LinkedHashMap<String, Object>();
+        
+    /**
+     * This method is called after initialisation but before the monitor is started.
+     * 
+     * It is a good place to initialise any instance variables.
+     */
+	@Override
+	protected void onPostInitialize() throws Exception {
+		// use logger provided by the BaseMonitor class
+		if (getLogger().isInfoEnabled()) {
+			getLogger().info("Initializing http client");
+		}
+		
+		// Setup global headlines once to use on each onCollect()
+		
+		// (1) Are there global headlines to apply to the views created by this monitor?
+		UserPropertiesConfig globalHeadlinesPropsConfig = SolGeneosAgent.onlyInstance.
+				getUserPropertiesConfig(GLOBAL_HEADLINES_PROPERTIES_FILE_NAME);
+		// If the file exists and its not empty, add each property as a headline:
+		if (globalHeadlinesPropsConfig != null && globalHeadlinesPropsConfig.getProperties() != null) {
+			globalHeadlinesPropsConfig.getProperties().forEach((key, value) -> globalHeadlines.put(key.toString() , value.toString()));
+		}
+		
+		// (2) Add this monitor's important details as headlines
+		globalHeadlines.put("Custom Monitor", this.getName() + " v" + MONITOR_VERSION);
+		globalHeadlines.put("Sampling Interval (secs)", this.getSamplingRate());		
+	
+		// (3) Retrieve SEMP over HTTP properties from global properties
+		Properties props = SolGeneosAgent.onlyInstance.getGlobalProperties();
+        String host = props.getProperty(MGMT_IP_ADDRESS_PROPERTY_NAME);
+        int port = 80;
+        try {
+        	port = Integer.parseInt(props.getProperty(MGMT_PORT_PROPERTY_NAME));
+        } catch (NumberFormatException e) {
+    		if (getLogger().isInfoEnabled()) {
+    			getLogger().info("Invalid port number, using default 80");
+    		}
+        }
+        String username = props.getProperty(MGMT_USERNAME_PROPERTY_NAME);
+        String password = SolGeneosAgent.onlyInstance.getEncryptedProperty(MGMT_ENCRYPTED_PASSWORD_PROPERTY_NAME,MGMT_PASSWORD_PROPERTY_NAME);
+		
+		// create a http client
+		httpClient = new DefaultHttpClient();
+		HttpParams httpParams = httpClient.getParams();
+				
+		// set connection target
+	    HttpHost target = new HttpHost(host, port);
+	    httpParams.setParameter(ClientPNames.DEFAULT_HOST, target);
+        
+        // set connection credential
+	    httpClient.getCredentialsProvider().setCredentials(
+	    		new AuthScope(host, port),
+                new UsernamePasswordCredentials(username, password));
+	    
+	    // response handler used http client to process http response and release
+	    // associated resources
+        responseHandler = new SampleResponseHandler();
+        
+        // create SEMP parser with the name of the element that contains the records
+		multiRecordParser = new MultiRecordSEMPParser(CLIENT_DETAILS_RESPONSE_ELEMENT_NAME);
+	}
+	
+	private void submitSEMPQuery (String sempQuery, SampleSEMPParser sempParser) throws Exception {
+		
+		// Get the first SEMP query response...
+		HttpPost post = new HttpPost(HTTP_REQUEST_URI);
+		post.setHeader(HEADER_CONTENT_TYPE_UTF8);
+		post.setEntity(new ByteArrayEntity(sempQuery.getBytes("UTF-8")));
+		
+		
+		SampleHttpSEMPResponse resp = httpClient.execute(post, responseHandler);
+        if (resp.getStatusCode() != 200) {
+        	throw new Exception("Error occurred while sending request: " + resp.getStatusCode() 
+        			+ " - " + resp.getReasonPhrase());
+        }	        
+        String respBody = resp.getRespBody();        
+        sempParser.parse(respBody);
+	}
+    
+	
+	/**
+	 * This method is responsible to collect data required for a view.
+	 * @return The next monitor state which should be State.REPORTING_QUEUE.
+	 */
+
+	@SuppressWarnings({ "static-access", "unchecked" })
+	@Override
+	protected State onCollect() throws Exception {
+
+		TreeMap<String, View> viewMap = getViewMap();
+		LinkedHashMap<String, Object> headlines = new LinkedHashMap<String, Object>();
+		
+		submitSEMPQuery(this.SHOW_CLIENTS_REQUEST, multiRecordParser);
+		
+		headlines.putAll(globalHeadlines);
+		
+		String lastSampleTime = SolGeneosAgent.onlyInstance.getCurrentTimeString();
+		headlines.put("Last Sample Time", lastSampleTime);
+		
+		tableContent = multiRecordParser.getTableContent();
+		
+		// Remove the internal '#client' client and convert bytes to MBytes
+		Iterator<Object> itr = tableContent.iterator();	
+		
+		while (itr.hasNext()) {		
+			ArrayList<String> tempTableRow = (ArrayList<String>) itr.next();
+			
+			String clientID = tempTableRow.get(DATAVIEW_COLUMN_NAMES.indexOf("Client ID"));
+			
+			if (clientID.startsWith("#client"))  {
+				itr.remove();
+			}
+			else
+			{
+				for (String columnName : COLUMNS_IN_MBYTES) {
+					double bytes = Double.parseDouble(tempTableRow.get(DATAVIEW_COLUMN_NAMES.indexOf(columnName)));
+					tempTableRow.set(DATAVIEW_COLUMN_NAMES.indexOf(columnName), String.format(FLOAT_FORMAT_STYLE, (bytes / BYTE_TO_MBYTE)));
+				}
+			}
+		}  
+
+		tableContent.add(0, this.DATAVIEW_COLUMN_NAMES);			
+		
+		// Now ready to publish tables to the view map
+    	if (viewMap != null && viewMap.size() > 0) {
+    		for (Iterator<String> viewIt = viewMap.keySet().iterator(); viewIt.hasNext();) 
+    		{
+    			View view = viewMap.get(viewIt.next());	
+    			if (view.isActive()) {
+    				view.setHeadlines(headlines);
+    				view.setTableContent(tableContent);
+    			}
+    		}
+    	}
+        return State.REPORTING_QUEUE;
+	}
+}

--- a/src/com/solacesystems/solgeneos/custommonitors/MessageVPNLimitsMonitor.java
+++ b/src/com/solacesystems/solgeneos/custommonitors/MessageVPNLimitsMonitor.java
@@ -191,10 +191,7 @@ public class MessageVPNLimitsMonitor extends BaseMonitor implements MonitorConst
 		globalHeadlines.put("Custom Monitor", this.getName() + " v" + MONITOR_VERSION);
 		globalHeadlines.put("Sampling Interval (secs)", this.getSamplingRate());		
 
-		// (3) Are there properties specific to this monitor in its config file?
-		// This monitor can be operated in two modes: (1) single view, or (2) multi view.
-		// In single view, all the queues are listed in the same dataview. In multi view mode, queues are reported in per-VPN dataviews
-		
+		// (3) Are there properties specific to this monitor in its config file?		
 		UserPropertiesConfig monitorPropsConfig = SolGeneosAgent.onlyInstance.
 				getUserPropertiesConfig(MONITOR_PROPERTIES_FILE_NAME_PREFIX + this.getName() +MONITOR_PROPERTIES_FILE_NAME_SUFFIX);
 		// If the file exists and its not empty, add each property as a headline:


### PR DESCRIPTION
**New Monitor:**

- ClientProfileLimits.   
A monitor to complement the resource monitoring done by the `MessageVPNLimits` monitor. This monitor displays the same resources set as limits at the client profile level.
- ClientsTopSubscribers.   
A monitor to complement the the `ClientsTopPublishers` monitor. This monitor displays a similar list of connected clients, just sorted by average receive rate instead. Monitors like this are useful data elements for dashboards.


**Enhancements:**

1. Previously the `MessagingTester` monitor was failing when queue tests cannot be performed because the broker does not support Assured Delivery (AD). Now queue based tests are optional.

**Updates:**

1. Clean up of code comments that were erroneous.  
