### PR TITLE
Enhanced QueuesEx and TopicEndpointsEx monitors to show bound consumer details

### DIFF
--- a/config/ClientProfileLimitsMonitor.properties
+++ b/config/ClientProfileLimitsMonitor.properties
@@ -3,7 +3,7 @@
 monitorClassName=com.solacesystems.solgeneos.custommonitors.ClientProfileLimitsMonitor
 
 # monitor sampling rate
-samplingRate=30
+samplingRate=90
 # auto start
 autoStart=true
 

--- a/config/MessageVPNLimitsMonitor.properties
+++ b/config/MessageVPNLimitsMonitor.properties
@@ -3,7 +3,7 @@
 monitorClassName=com.solacesystems.solgeneos.custommonitors.MessageVPNLimitsMonitor
 
 # monitor sampling rate
-samplingRate=60
+samplingRate=90
 # auto start
 autoStart=true
 

--- a/config/QueuesExMonitor.properties
+++ b/config/QueuesExMonitor.properties
@@ -3,7 +3,7 @@
 monitorClassName=com.solacesystems.solgeneos.custommonitors.QueuesExMonitor
 
 # monitor sampling rate
-samplingRate=30
+samplingRate=45
 # auto start
 autoStart=true
 

--- a/config/TopicEndpointsExMonitor.properties
+++ b/config/TopicEndpointsExMonitor.properties
@@ -3,7 +3,7 @@
 monitorClassName=com.solacesystems.solgeneos.custommonitors.TopicEndpointsExMonitor
 
 # monitor sampling rate
-samplingRate=30
+samplingRate=45
 # auto start
 autoStart=true
 

--- a/geneos-rules/Geneos Rules Group - Custom Monitors v1.0.0 - XML.xml
+++ b/geneos-rules/Geneos Rules Group - Custom Monitors v1.0.0 - XML.xml
@@ -273,483 +273,6 @@
             </block>
         </rule>
     </ruleGroup>
-    <ruleGroup name="ClientProfileLimits">
-        <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
-        <rule name="Connections">
-            <targets>
-                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row[wild(@name,&quot;*&quot;)]/cell[(@column=&quot;Connections - Current&quot;)]</target>
-            </targets>
-            <priority>100</priority>
-            <pathAliases>
-                <pathAlias name="Max Configured">../cell[(@column=&quot;Connections - Max&quot;)]</pathAlias>
-            </pathAliases>
-            <block>
-                <!-- Rule to check the current usage against the profile maximum configured limit-->
-                <!-- Currently looking at all rows, i.e. all profiles. Can replace the wildcard * with a VPN name for more targeted rule application for individual teams-->
-                <set>
-                    <var ref="max_configured"></var>
-                    <dataItem>
-                        <pathAlias ref="Max Configured"></pathAlias>
-                        <property>@value</property>
-                    </dataItem>
-                </set>
-                <set>
-                    <var ref="high_threshold"></var>
-                    <integer>65</integer>
-                </set>
-                <set>
-                    <var ref="exceed_threshold"></var>
-                    <integer>80</integer>
-                </set>
-                <set>
-                    <var ref="value"></var>
-                    <multiply>
-                        <divide>
-                            <dataItem>
-                                <property>@value</property>
-                            </dataItem>
-                            <var ref="max_configured"></var>
-                        </divide>
-                        <integer>100</integer>
-                    </multiply>
-                </set>
-                <if>
-                    <and>
-                        <lt>
-                            <var ref="value"></var>
-                            <var ref="high_threshold"></var>
-                        </lt>
-                        <equal>
-                            <dataItem>
-                                <property>state/@severity</property>
-                            </dataItem>
-                            <severity>undefined</severity>
-                        </equal>
-                    </and>
-                    <transaction>
-                        <update>
-                            <property>state/@severity</property>
-                            <severity>ok</severity>
-                        </update>
-                    </transaction>
-                    <if>
-                        <lt>
-                            <var ref="value"></var>
-                            <var ref="high_threshold"></var>
-                        </lt>
-                        <transaction>
-                            <delay>300</delay>
-                            <update>
-                                <property>state/@severity</property>
-                                <severity>ok</severity>
-                            </update>
-                        </transaction>
-                        <if>
-                            <and>
-                                <and>
-                                    <gte>
-                                        <var ref="value"></var>
-                                        <var ref="high_threshold"></var>
-                                    </gte>
-                                    <lte>
-                                        <var ref="value"></var>
-                                        <var ref="exceed_threshold"></var>
-                                    </lte>
-                                </and>
-                                <notEqual>
-                                    <dataItem>
-                                        <property>state/@severity</property>
-                                    </dataItem>
-                                    <severity>warning</severity>
-                                </notEqual>
-                            </and>
-                            <transaction>
-                                <update>
-                                    <property>state/@severity</property>
-                                    <severity>warning</severity>
-                                </update>
-                            </transaction>
-                            <if>
-                                <and>
-                                    <gt>
-                                        <var ref="value"></var>
-                                        <var ref="exceed_threshold"></var>
-                                    </gt>
-                                    <notEqual>
-                                        <dataItem>
-                                            <property>state/@severity</property>
-                                        </dataItem>
-                                        <severity>critical</severity>
-                                    </notEqual>
-                                </and>
-                                <transaction>
-                                    <update>
-                                        <property>state/@severity</property>
-                                        <severity>critical</severity>
-                                    </update>
-                                </transaction>
-                            </if>
-                        </if>
-                    </if>
-                </if>
-            </block>
-        </rule>
-        <rule name="Subscriptions">
-            <targets>
-                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row[wild(@name,&quot;*&quot;)]/cell[(@column=&quot;Subscriptions - Current&quot;)]</target>
-            </targets>
-            <priority>100</priority>
-            <pathAliases>
-                <pathAlias name="Max Configured">../cell[(@column=&quot;Subscriptions - Max&quot;)]</pathAlias>
-            </pathAliases>
-            <block>
-                <!-- Rule to check the current usage against the profile maximum configured limit-->
-                <!-- Currently looking at all rows, i.e. all VPNs. Can replace the wildcard * with a VPN name for more targeted rule application for individual teams-->
-                <set>
-                    <var ref="max_configured"></var>
-                    <dataItem>
-                        <pathAlias ref="Max Configured"></pathAlias>
-                        <property>@value</property>
-                    </dataItem>
-                </set>
-                <set>
-                    <var ref="high_threshold"></var>
-                    <integer>65</integer>
-                </set>
-                <set>
-                    <var ref="exceed_threshold"></var>
-                    <integer>80</integer>
-                </set>
-                <set>
-                    <var ref="value"></var>
-                    <multiply>
-                        <divide>
-                            <dataItem>
-                                <property>@value</property>
-                            </dataItem>
-                            <var ref="max_configured"></var>
-                        </divide>
-                        <integer>100</integer>
-                    </multiply>
-                </set>
-                <if>
-                    <and>
-                        <lt>
-                            <var ref="value"></var>
-                            <var ref="high_threshold"></var>
-                        </lt>
-                        <equal>
-                            <dataItem>
-                                <property>state/@severity</property>
-                            </dataItem>
-                            <severity>undefined</severity>
-                        </equal>
-                    </and>
-                    <transaction>
-                        <update>
-                            <property>state/@severity</property>
-                            <severity>ok</severity>
-                        </update>
-                    </transaction>
-                    <if>
-                        <lt>
-                            <var ref="value"></var>
-                            <var ref="high_threshold"></var>
-                        </lt>
-                        <transaction>
-                            <delay>300</delay>
-                            <update>
-                                <property>state/@severity</property>
-                                <severity>ok</severity>
-                            </update>
-                        </transaction>
-                        <if>
-                            <and>
-                                <and>
-                                    <gte>
-                                        <var ref="value"></var>
-                                        <var ref="high_threshold"></var>
-                                    </gte>
-                                    <lte>
-                                        <var ref="value"></var>
-                                        <var ref="exceed_threshold"></var>
-                                    </lte>
-                                </and>
-                                <notEqual>
-                                    <dataItem>
-                                        <property>state/@severity</property>
-                                    </dataItem>
-                                    <severity>warning</severity>
-                                </notEqual>
-                            </and>
-                            <transaction>
-                                <update>
-                                    <property>state/@severity</property>
-                                    <severity>warning</severity>
-                                </update>
-                            </transaction>
-                            <if>
-                                <and>
-                                    <gt>
-                                        <var ref="value"></var>
-                                        <var ref="exceed_threshold"></var>
-                                    </gt>
-                                    <notEqual>
-                                        <dataItem>
-                                            <property>state/@severity</property>
-                                        </dataItem>
-                                        <severity>critical</severity>
-                                    </notEqual>
-                                </and>
-                                <transaction>
-                                    <update>
-                                        <property>state/@severity</property>
-                                        <severity>critical</severity>
-                                    </update>
-                                </transaction>
-                            </if>
-                        </if>
-                    </if>
-                </if>
-            </block>
-        </rule>
-        <rule name="Ingress Flows">
-            <targets>
-                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row/cell[(@column=&quot;Ingress Flows - Current&quot;)]</target>
-            </targets>
-            <priority>100</priority>
-            <pathAliases>
-                <pathAlias name="Max Configured">../cell[(@column=&quot;Ingress Flows - Max&quot;)]</pathAlias>
-            </pathAliases>
-            <block>
-                <!-- Rule to check the current usage against the profile maximum configured limit-->
-                <set>
-                    <var ref="max_configured"></var>
-                    <dataItem>
-                        <pathAlias ref="Max Configured"></pathAlias>
-                        <property>@value</property>
-                    </dataItem>
-                </set>
-                <set>
-                    <var ref="high_threshold"></var>
-                    <integer>65</integer>
-                </set>
-                <set>
-                    <var ref="exceed_threshold"></var>
-                    <integer>80</integer>
-                </set>
-                <set>
-                    <var ref="value"></var>
-                    <multiply>
-                        <divide>
-                            <dataItem>
-                                <property>@value</property>
-                            </dataItem>
-                            <var ref="max_configured"></var>
-                        </divide>
-                        <integer>100</integer>
-                    </multiply>
-                </set>
-                <if>
-                    <and>
-                        <lt>
-                            <var ref="value"></var>
-                            <var ref="high_threshold"></var>
-                        </lt>
-                        <equal>
-                            <dataItem>
-                                <property>state/@severity</property>
-                            </dataItem>
-                            <severity>undefined</severity>
-                        </equal>
-                    </and>
-                    <transaction>
-                        <update>
-                            <property>state/@severity</property>
-                            <severity>ok</severity>
-                        </update>
-                    </transaction>
-                    <if>
-                        <lt>
-                            <var ref="value"></var>
-                            <var ref="high_threshold"></var>
-                        </lt>
-                        <transaction>
-                            <delay>300</delay>
-                            <update>
-                                <property>state/@severity</property>
-                                <severity>ok</severity>
-                            </update>
-                        </transaction>
-                        <if>
-                            <and>
-                                <and>
-                                    <gte>
-                                        <var ref="value"></var>
-                                        <var ref="high_threshold"></var>
-                                    </gte>
-                                    <lte>
-                                        <var ref="value"></var>
-                                        <var ref="exceed_threshold"></var>
-                                    </lte>
-                                </and>
-                                <notEqual>
-                                    <dataItem>
-                                        <property>state/@severity</property>
-                                    </dataItem>
-                                    <severity>warning</severity>
-                                </notEqual>
-                            </and>
-                            <transaction>
-                                <update>
-                                    <property>state/@severity</property>
-                                    <severity>warning</severity>
-                                </update>
-                            </transaction>
-                            <if>
-                                <and>
-                                    <gt>
-                                        <var ref="value"></var>
-                                        <var ref="exceed_threshold"></var>
-                                    </gt>
-                                    <notEqual>
-                                        <dataItem>
-                                            <property>state/@severity</property>
-                                        </dataItem>
-                                        <severity>critical</severity>
-                                    </notEqual>
-                                </and>
-                                <transaction>
-                                    <update>
-                                        <property>state/@severity</property>
-                                        <severity>critical</severity>
-                                    </update>
-                                </transaction>
-                            </if>
-                        </if>
-                    </if>
-                </if>
-            </block>
-        </rule>
-        <rule name="Egress Flows">
-            <targets>
-                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row/cell[(@column=&quot;Egress Flows - Current&quot;)]</target>
-            </targets>
-            <priority>100</priority>
-            <pathAliases>
-                <pathAlias name="Max Configured">../cell[(@column=&quot;Egress Flows - Max&quot;)]</pathAlias>
-            </pathAliases>
-            <block>
-                <!-- Rule to check the current usage against the profile maximum configured limit-->
-                <set>
-                    <var ref="max_configured"></var>
-                    <dataItem>
-                        <pathAlias ref="Max Configured"></pathAlias>
-                        <property>@value</property>
-                    </dataItem>
-                </set>
-                <set>
-                    <var ref="high_threshold"></var>
-                    <integer>65</integer>
-                </set>
-                <set>
-                    <var ref="exceed_threshold"></var>
-                    <integer>80</integer>
-                </set>
-                <set>
-                    <var ref="value"></var>
-                    <multiply>
-                        <divide>
-                            <dataItem>
-                                <property>@value</property>
-                            </dataItem>
-                            <var ref="max_configured"></var>
-                        </divide>
-                        <integer>100</integer>
-                    </multiply>
-                </set>
-                <if>
-                    <and>
-                        <lt>
-                            <var ref="value"></var>
-                            <var ref="high_threshold"></var>
-                        </lt>
-                        <equal>
-                            <dataItem>
-                                <property>state/@severity</property>
-                            </dataItem>
-                            <severity>undefined</severity>
-                        </equal>
-                    </and>
-                    <transaction>
-                        <update>
-                            <property>state/@severity</property>
-                            <severity>ok</severity>
-                        </update>
-                    </transaction>
-                    <if>
-                        <lt>
-                            <var ref="value"></var>
-                            <var ref="high_threshold"></var>
-                        </lt>
-                        <transaction>
-                            <delay>300</delay>
-                            <update>
-                                <property>state/@severity</property>
-                                <severity>ok</severity>
-                            </update>
-                        </transaction>
-                        <if>
-                            <and>
-                                <and>
-                                    <gte>
-                                        <var ref="value"></var>
-                                        <var ref="high_threshold"></var>
-                                    </gte>
-                                    <lte>
-                                        <var ref="value"></var>
-                                        <var ref="exceed_threshold"></var>
-                                    </lte>
-                                </and>
-                                <notEqual>
-                                    <dataItem>
-                                        <property>state/@severity</property>
-                                    </dataItem>
-                                    <severity>warning</severity>
-                                </notEqual>
-                            </and>
-                            <transaction>
-                                <update>
-                                    <property>state/@severity</property>
-                                    <severity>warning</severity>
-                                </update>
-                            </transaction>
-                            <if>
-                                <and>
-                                    <gt>
-                                        <var ref="value"></var>
-                                        <var ref="exceed_threshold"></var>
-                                    </gt>
-                                    <notEqual>
-                                        <dataItem>
-                                            <property>state/@severity</property>
-                                        </dataItem>
-                                        <severity>critical</severity>
-                                    </notEqual>
-                                </and>
-                                <transaction>
-                                    <update>
-                                        <property>state/@severity</property>
-                                        <severity>critical</severity>
-                                    </update>
-                                </transaction>
-                            </if>
-                        </if>
-                    </if>
-                </if>
-            </block>
-        </rule>
-    </ruleGroup>
     <ruleGroup name="MessageVPNLimits">
         <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
         <rule name="Connections SMF">
@@ -1699,6 +1222,483 @@
             </block>
         </rule>
     </ruleGroup>
+    <ruleGroup name="ClientProfileLimits">
+        <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
+        <rule name="Connections">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row[wild(@name,&quot;*&quot;)]/cell[(@column=&quot;Connections - Current&quot;)]</target>
+            </targets>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Max Configured">../cell[(@column=&quot;Connections - Max&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- Rule to check the current usage against the profile maximum configured limit-->
+                <!-- Currently looking at all rows, i.e. all profiles. Can replace the wildcard * with a VPN name for more targeted rule application for individual teams-->
+                <set>
+                    <var ref="max_configured"></var>
+                    <dataItem>
+                        <pathAlias ref="Max Configured"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <set>
+                    <var ref="high_threshold"></var>
+                    <integer>65</integer>
+                </set>
+                <set>
+                    <var ref="exceed_threshold"></var>
+                    <integer>80</integer>
+                </set>
+                <set>
+                    <var ref="value"></var>
+                    <multiply>
+                        <divide>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                            <var ref="max_configured"></var>
+                        </divide>
+                        <integer>100</integer>
+                    </multiply>
+                </set>
+                <if>
+                    <and>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <equal>
+                            <dataItem>
+                                <property>state/@severity</property>
+                            </dataItem>
+                            <severity>undefined</severity>
+                        </equal>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>state/@severity</property>
+                            <severity>ok</severity>
+                        </update>
+                    </transaction>
+                    <if>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <transaction>
+                            <delay>300</delay>
+                            <update>
+                                <property>state/@severity</property>
+                                <severity>ok</severity>
+                            </update>
+                        </transaction>
+                        <if>
+                            <and>
+                                <and>
+                                    <gte>
+                                        <var ref="value"></var>
+                                        <var ref="high_threshold"></var>
+                                    </gte>
+                                    <lte>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </lte>
+                                </and>
+                                <notEqual>
+                                    <dataItem>
+                                        <property>state/@severity</property>
+                                    </dataItem>
+                                    <severity>warning</severity>
+                                </notEqual>
+                            </and>
+                            <transaction>
+                                <update>
+                                    <property>state/@severity</property>
+                                    <severity>warning</severity>
+                                </update>
+                            </transaction>
+                            <if>
+                                <and>
+                                    <gt>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </gt>
+                                    <notEqual>
+                                        <dataItem>
+                                            <property>state/@severity</property>
+                                        </dataItem>
+                                        <severity>critical</severity>
+                                    </notEqual>
+                                </and>
+                                <transaction>
+                                    <update>
+                                        <property>state/@severity</property>
+                                        <severity>critical</severity>
+                                    </update>
+                                </transaction>
+                            </if>
+                        </if>
+                    </if>
+                </if>
+            </block>
+        </rule>
+        <rule name="Subscriptions">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row[wild(@name,&quot;*&quot;)]/cell[(@column=&quot;Subscriptions - Current&quot;)]</target>
+            </targets>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Max Configured">../cell[(@column=&quot;Subscriptions - Max&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- Rule to check the current usage against the profile maximum configured limit-->
+                <!-- Currently looking at all rows, i.e. all VPNs. Can replace the wildcard * with a VPN name for more targeted rule application for individual teams-->
+                <set>
+                    <var ref="max_configured"></var>
+                    <dataItem>
+                        <pathAlias ref="Max Configured"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <set>
+                    <var ref="high_threshold"></var>
+                    <integer>65</integer>
+                </set>
+                <set>
+                    <var ref="exceed_threshold"></var>
+                    <integer>80</integer>
+                </set>
+                <set>
+                    <var ref="value"></var>
+                    <multiply>
+                        <divide>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                            <var ref="max_configured"></var>
+                        </divide>
+                        <integer>100</integer>
+                    </multiply>
+                </set>
+                <if>
+                    <and>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <equal>
+                            <dataItem>
+                                <property>state/@severity</property>
+                            </dataItem>
+                            <severity>undefined</severity>
+                        </equal>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>state/@severity</property>
+                            <severity>ok</severity>
+                        </update>
+                    </transaction>
+                    <if>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <transaction>
+                            <delay>300</delay>
+                            <update>
+                                <property>state/@severity</property>
+                                <severity>ok</severity>
+                            </update>
+                        </transaction>
+                        <if>
+                            <and>
+                                <and>
+                                    <gte>
+                                        <var ref="value"></var>
+                                        <var ref="high_threshold"></var>
+                                    </gte>
+                                    <lte>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </lte>
+                                </and>
+                                <notEqual>
+                                    <dataItem>
+                                        <property>state/@severity</property>
+                                    </dataItem>
+                                    <severity>warning</severity>
+                                </notEqual>
+                            </and>
+                            <transaction>
+                                <update>
+                                    <property>state/@severity</property>
+                                    <severity>warning</severity>
+                                </update>
+                            </transaction>
+                            <if>
+                                <and>
+                                    <gt>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </gt>
+                                    <notEqual>
+                                        <dataItem>
+                                            <property>state/@severity</property>
+                                        </dataItem>
+                                        <severity>critical</severity>
+                                    </notEqual>
+                                </and>
+                                <transaction>
+                                    <update>
+                                        <property>state/@severity</property>
+                                        <severity>critical</severity>
+                                    </update>
+                                </transaction>
+                            </if>
+                        </if>
+                    </if>
+                </if>
+            </block>
+        </rule>
+        <rule name="Ingress Flows">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row/cell[(@column=&quot;Ingress Flows - Current&quot;)]</target>
+            </targets>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Max Configured">../cell[(@column=&quot;Ingress Flows - Max&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- Rule to check the current usage against the profile maximum configured limit-->
+                <set>
+                    <var ref="max_configured"></var>
+                    <dataItem>
+                        <pathAlias ref="Max Configured"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <set>
+                    <var ref="high_threshold"></var>
+                    <integer>65</integer>
+                </set>
+                <set>
+                    <var ref="exceed_threshold"></var>
+                    <integer>80</integer>
+                </set>
+                <set>
+                    <var ref="value"></var>
+                    <multiply>
+                        <divide>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                            <var ref="max_configured"></var>
+                        </divide>
+                        <integer>100</integer>
+                    </multiply>
+                </set>
+                <if>
+                    <and>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <equal>
+                            <dataItem>
+                                <property>state/@severity</property>
+                            </dataItem>
+                            <severity>undefined</severity>
+                        </equal>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>state/@severity</property>
+                            <severity>ok</severity>
+                        </update>
+                    </transaction>
+                    <if>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <transaction>
+                            <delay>300</delay>
+                            <update>
+                                <property>state/@severity</property>
+                                <severity>ok</severity>
+                            </update>
+                        </transaction>
+                        <if>
+                            <and>
+                                <and>
+                                    <gte>
+                                        <var ref="value"></var>
+                                        <var ref="high_threshold"></var>
+                                    </gte>
+                                    <lte>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </lte>
+                                </and>
+                                <notEqual>
+                                    <dataItem>
+                                        <property>state/@severity</property>
+                                    </dataItem>
+                                    <severity>warning</severity>
+                                </notEqual>
+                            </and>
+                            <transaction>
+                                <update>
+                                    <property>state/@severity</property>
+                                    <severity>warning</severity>
+                                </update>
+                            </transaction>
+                            <if>
+                                <and>
+                                    <gt>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </gt>
+                                    <notEqual>
+                                        <dataItem>
+                                            <property>state/@severity</property>
+                                        </dataItem>
+                                        <severity>critical</severity>
+                                    </notEqual>
+                                </and>
+                                <transaction>
+                                    <update>
+                                        <property>state/@severity</property>
+                                        <severity>critical</severity>
+                                    </update>
+                                </transaction>
+                            </if>
+                        </if>
+                    </if>
+                </if>
+            </block>
+        </rule>
+        <rule name="Egress Flows">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;ClientProfileLimits&quot;)]/rows/row/cell[(@column=&quot;Egress Flows - Current&quot;)]</target>
+            </targets>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Max Configured">../cell[(@column=&quot;Egress Flows - Max&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- Rule to check the current usage against the profile maximum configured limit-->
+                <set>
+                    <var ref="max_configured"></var>
+                    <dataItem>
+                        <pathAlias ref="Max Configured"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <set>
+                    <var ref="high_threshold"></var>
+                    <integer>65</integer>
+                </set>
+                <set>
+                    <var ref="exceed_threshold"></var>
+                    <integer>80</integer>
+                </set>
+                <set>
+                    <var ref="value"></var>
+                    <multiply>
+                        <divide>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                            <var ref="max_configured"></var>
+                        </divide>
+                        <integer>100</integer>
+                    </multiply>
+                </set>
+                <if>
+                    <and>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <equal>
+                            <dataItem>
+                                <property>state/@severity</property>
+                            </dataItem>
+                            <severity>undefined</severity>
+                        </equal>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>state/@severity</property>
+                            <severity>ok</severity>
+                        </update>
+                    </transaction>
+                    <if>
+                        <lt>
+                            <var ref="value"></var>
+                            <var ref="high_threshold"></var>
+                        </lt>
+                        <transaction>
+                            <delay>300</delay>
+                            <update>
+                                <property>state/@severity</property>
+                                <severity>ok</severity>
+                            </update>
+                        </transaction>
+                        <if>
+                            <and>
+                                <and>
+                                    <gte>
+                                        <var ref="value"></var>
+                                        <var ref="high_threshold"></var>
+                                    </gte>
+                                    <lte>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </lte>
+                                </and>
+                                <notEqual>
+                                    <dataItem>
+                                        <property>state/@severity</property>
+                                    </dataItem>
+                                    <severity>warning</severity>
+                                </notEqual>
+                            </and>
+                            <transaction>
+                                <update>
+                                    <property>state/@severity</property>
+                                    <severity>warning</severity>
+                                </update>
+                            </transaction>
+                            <if>
+                                <and>
+                                    <gt>
+                                        <var ref="value"></var>
+                                        <var ref="exceed_threshold"></var>
+                                    </gt>
+                                    <notEqual>
+                                        <dataItem>
+                                            <property>state/@severity</property>
+                                        </dataItem>
+                                        <severity>critical</severity>
+                                    </notEqual>
+                                </and>
+                                <transaction>
+                                    <update>
+                                        <property>state/@severity</property>
+                                        <severity>critical</severity>
+                                    </update>
+                                </transaction>
+                            </if>
+                        </if>
+                    </if>
+                </if>
+            </block>
+        </rule>
+    </ruleGroup>
     <ruleGroup name="QueuesEx">
         <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
         <rule name="Spool Usage">
@@ -2095,6 +2095,86 @@
                 </if>
             </block>
         </rule>
+        <rule name="Last Seen Client ID">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;QueuesEx&quot;)]/rows/row/cell[(@column=&quot;Last Seen Client ID&quot;)]</target>
+            </targets>
+            <priorityGroup>100</priorityGroup>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Client ID">../cell[(@column=&quot;Client ID&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- A rule watch for changes in the "Client ID" column and save non-empty values into this column dynamically-->
+                <set>
+                    <var ref="client_id"></var>
+                    <dataItem>
+                        <pathAlias ref="Client ID"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <if>
+                    <and>
+                        <notEqual>
+                            <var ref="client_id"></var>
+                            <string></string>
+                        </notEqual>
+                        <notEqual>
+                            <var ref="client_id"></var>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                        </notEqual>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>@value</property>
+                            <var ref="client_id"></var>
+                        </update>
+                    </transaction>
+                </if>
+            </block>
+        </rule>
+        <rule name="Last Seen Connect Time">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;QueuesEx&quot;)]/rows/row/cell[(@column=&quot;Last Seen Connect Time&quot;)]</target>
+            </targets>
+            <priorityGroup>100</priorityGroup>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Connect Time">../cell[(@column=&quot;Connect Time&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- A rule watch for changes in the "Connect Time" column and save non-empty values into this column dynamically-->
+                <set>
+                    <var ref="connect_time"></var>
+                    <dataItem>
+                        <pathAlias ref="Connect Time"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <if>
+                    <and>
+                        <notEqual>
+                            <var ref="connect_time"></var>
+                            <string></string>
+                        </notEqual>
+                        <notEqual>
+                            <var ref="connect_time"></var>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                        </notEqual>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>@value</property>
+                            <var ref="connect_time"></var>
+                        </update>
+                    </transaction>
+                </if>
+            </block>
+        </rule>
     </ruleGroup>
     <ruleGroup name="TopicEndpointsEx">
         <!-- Rule samples from https://github.com/SolaceLabs/solace-custom-monitor-solgeneos/ -->
@@ -2303,8 +2383,10 @@
                 </set>
                 <if>
                     <equal>
-                        <var ref="durable"></var>
-                        <string>false</string>
+                        <dataItem>
+                            <property>@value</property>
+                        </dataItem>
+                        <string></string>
                     </equal>
                     <transaction>
                         <update>
@@ -2313,48 +2395,14 @@
                         </update>
                     </transaction>
                     <if>
-                        <and>
-                            <and>
-                                <and>
-                                    <and>
-                                        <gt>
-                                            <var ref="bind_count"></var>
-                                            <integer>0</integer>
-                                        </gt>
-                                        <equal>
-                                            <dataItem>
-                                                <property>@value</property>
-                                            </dataItem>
-                                            <dataItem>
-                                                <property>@value</property>
-                                                <previous>true</previous>
-                                            </dataItem>
-                                        </equal>
-                                    </and>
-                                    <lte>
-                                        <dataItem>
-                                            <property>state/@severity</property>
-                                        </dataItem>
-                                        <severity>ok</severity>
-                                    </lte>
-                                </and>
-                                <notEqual>
-                                    <var ref="new_msg_id"></var>
-                                    <integer>0</integer>
-                                </notEqual>
-                            </and>
-                            <gt>
-                                <var ref="new_msg_id"></var>
-                                <dataItem>
-                                    <property>@value</property>
-                                </dataItem>
-                            </gt>
-                        </and>
+                        <equal>
+                            <var ref="durable"></var>
+                            <string>false</string>
+                        </equal>
                         <transaction>
-                            <delay unit="seconds">900</delay>
                             <update>
                                 <property>state/@severity</property>
-                                <severity>warning</severity>
+                                <severity>undefined</severity>
                             </update>
                         </transaction>
                         <if>
@@ -2362,34 +2410,26 @@
                                 <and>
                                     <and>
                                         <and>
-                                            <and>
-                                                <gt>
-                                                    <var ref="bind_count"></var>
-                                                    <integer>0</integer>
-                                                </gt>
-                                                <equal>
-                                                    <dataItem>
-                                                        <property>@value</property>
-                                                    </dataItem>
-                                                    <dataItem>
-                                                        <property>@value</property>
-                                                        <previous>true</previous>
-                                                    </dataItem>
-                                                </equal>
-                                            </and>
+                                            <gt>
+                                                <var ref="bind_count"></var>
+                                                <integer>0</integer>
+                                            </gt>
                                             <equal>
                                                 <dataItem>
-                                                    <property>state/@severity</property>
+                                                    <property>@value</property>
                                                 </dataItem>
-                                                <severity>warning</severity>
+                                                <dataItem>
+                                                    <property>@value</property>
+                                                    <previous>true</previous>
+                                                </dataItem>
                                             </equal>
                                         </and>
-                                        <notEqual>
+                                        <lte>
                                             <dataItem>
                                                 <property>state/@severity</property>
                                             </dataItem>
-                                            <severity>critical</severity>
-                                        </notEqual>
+                                            <severity>ok</severity>
+                                        </lte>
                                     </and>
                                     <notEqual>
                                         <var ref="new_msg_id"></var>
@@ -2404,45 +2444,165 @@
                                 </gt>
                             </and>
                             <transaction>
-                                <delay unit="seconds">1800</delay>
+                                <delay unit="seconds">900</delay>
                                 <update>
                                     <property>state/@severity</property>
-                                    <severity>critical</severity>
+                                    <severity>warning</severity>
                                 </update>
                             </transaction>
                             <if>
-                                <gt>
-                                    <dataItem>
-                                        <property>@value</property>
-                                    </dataItem>
-                                    <dataItem>
-                                        <property>@value</property>
-                                        <previous>true</previous>
-                                    </dataItem>
-                                </gt>
-                                <transaction>
-                                    <update>
-                                        <property>state/@severity</property>
-                                        <severity>ok</severity>
-                                    </update>
-                                </transaction>
-                                <if>
-                                    <equal>
+                                <and>
+                                    <and>
+                                        <and>
+                                            <and>
+                                                <and>
+                                                    <gt>
+                                                        <var ref="bind_count"></var>
+                                                        <integer>0</integer>
+                                                    </gt>
+                                                    <equal>
+                                                        <dataItem>
+                                                            <property>@value</property>
+                                                        </dataItem>
+                                                        <dataItem>
+                                                            <property>@value</property>
+                                                            <previous>true</previous>
+                                                        </dataItem>
+                                                    </equal>
+                                                </and>
+                                                <equal>
+                                                    <dataItem>
+                                                        <property>state/@severity</property>
+                                                    </dataItem>
+                                                    <severity>warning</severity>
+                                                </equal>
+                                            </and>
+                                            <notEqual>
+                                                <dataItem>
+                                                    <property>state/@severity</property>
+                                                </dataItem>
+                                                <severity>critical</severity>
+                                            </notEqual>
+                                        </and>
+                                        <notEqual>
+                                            <var ref="new_msg_id"></var>
+                                            <integer>0</integer>
+                                        </notEqual>
+                                    </and>
+                                    <gt>
+                                        <var ref="new_msg_id"></var>
                                         <dataItem>
                                             <property>@value</property>
                                         </dataItem>
-                                        <string></string>
-                                    </equal>
+                                    </gt>
+                                </and>
+                                <transaction>
+                                    <delay unit="seconds">1800</delay>
+                                    <update>
+                                        <property>state/@severity</property>
+                                        <severity>critical</severity>
+                                    </update>
+                                </transaction>
+                                <if>
+                                    <gt>
+                                        <dataItem>
+                                            <property>@value</property>
+                                        </dataItem>
+                                        <dataItem>
+                                            <property>@value</property>
+                                            <previous>true</previous>
+                                        </dataItem>
+                                    </gt>
                                     <transaction>
                                         <update>
                                             <property>state/@severity</property>
-                                            <severity>undefined</severity>
+                                            <severity>ok</severity>
                                         </update>
                                     </transaction>
                                 </if>
                             </if>
                         </if>
                     </if>
+                </if>
+            </block>
+        </rule>
+        <rule name="Last Seen Client ID">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;TopicEndpointsEx&quot;)]/rows/row/cell[(@column=&quot;Last Seen Client ID&quot;)]</target>
+            </targets>
+            <priorityGroup>100</priorityGroup>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Client ID">../cell[(@column=&quot;Client ID&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- A rule watch for changes in the "Client ID" column and save non-empty values into this column dynamically-->
+                <set>
+                    <var ref="client_id"></var>
+                    <dataItem>
+                        <pathAlias ref="Client ID"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <if>
+                    <and>
+                        <notEqual>
+                            <var ref="client_id"></var>
+                            <string></string>
+                        </notEqual>
+                        <notEqual>
+                            <var ref="client_id"></var>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                        </notEqual>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>@value</property>
+                            <var ref="client_id"></var>
+                        </update>
+                    </transaction>
+                </if>
+            </block>
+        </rule>
+        <rule name="Last Seen Connect Time">
+            <targets>
+                <target>/geneos/gateway/directory/probe/managedEntity/sampler/dataview[(@name=&quot;TopicEndpointsEx&quot;)]/rows/row/cell[(@column=&quot;Last Seen Connect Time&quot;)]</target>
+            </targets>
+            <priorityGroup>100</priorityGroup>
+            <priority>100</priority>
+            <pathAliases>
+                <pathAlias name="Connect Time">../cell[(@column=&quot;Connect Time&quot;)]</pathAlias>
+            </pathAliases>
+            <block>
+                <!-- A rule watch for changes in the "Connect Time" column and save non-empty values into this column dynamically-->
+                <set>
+                    <var ref="connect_time"></var>
+                    <dataItem>
+                        <pathAlias ref="Connect Time"></pathAlias>
+                        <property>@value</property>
+                    </dataItem>
+                </set>
+                <if>
+                    <and>
+                        <notEqual>
+                            <var ref="connect_time"></var>
+                            <string></string>
+                        </notEqual>
+                        <notEqual>
+                            <var ref="connect_time"></var>
+                            <dataItem>
+                                <property>@value</property>
+                            </dataItem>
+                        </notEqual>
+                    </and>
+                    <transaction>
+                        <update>
+                            <property>@value</property>
+                            <var ref="connect_time"></var>
+                        </update>
+                    </transaction>
                 </if>
             </block>
         </rule>

--- a/src/com/solacesystems/solgeneos/custommonitors/ClientProfileLimitsMonitor.java
+++ b/src/com/solacesystems/solgeneos/custommonitors/ClientProfileLimitsMonitor.java
@@ -37,7 +37,7 @@ import com.solacesystems.solgeneos.solgeneosagent.monitor.View;
 public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorConstants {
   
 	// What version of the monitor?
-	static final public String MONITOR_VERSION = "1.0.0";
+	static final public String MONITOR_VERSION = "1.0.1";
 	
 	// The SEMP queries to execute:
     static final public String SHOW_CP_DETAILS_REQUEST = 
@@ -80,7 +80,7 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
     private List<Integer> desiredColumnOrder;
     
     // Override the column names to more human friendly
-    static final private List<String> CP_LIMITS_DATAVIEW_COLUMN_NAMES = 
+    static final private ArrayList<String> CP_LIMITS_DATAVIEW_COLUMN_NAMES = new ArrayList<String>(
     		Arrays.asList("RowUID", "Client Profile", "Message VPN", 
     				"Subscriptions - Current", "Subscriptions - Max",
     				"Connections - Current", "Connections - Max", 
@@ -91,7 +91,7 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
     				"Transacted Sessions - Max",
     				"Number of Users",
     				"Utilisation Score"
-    				);
+    				));
     
     static final String[] RESOURCES = {"Subscriptions", "Connections", "Egress Flows", "Ingress Flows"};
     
@@ -257,11 +257,11 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
 		}
 				
 		// Will take what is received as the table contents and then do further Java8 Streams based processing... 
-		Vector<Object> clientProfileData;
-		Vector<Object> clientProfileDataTemp;
+		Vector<ArrayList<String>> clientProfileData;
+		Vector<ArrayList<String>> clientProfileDataTemp;
 		ArrayList<String> tableRowClientProfile;
 		
-		Vector<Object> clientData;
+		Vector<ArrayList<String>> clientData;
 		ArrayList<String> tableRowClient;
 		
 		clientProfileData = multiRecordParserClientProfile.getTableContent();
@@ -269,7 +269,7 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
 		List<String> clientDataColumnNames = multiRecordParserClientDetail.getColumnNames();
 		
 		// Reorder the merged table into the column order we want. 
-		clientProfileDataTemp = new Vector<Object>();
+		clientProfileDataTemp = new Vector<ArrayList<String>>();
 		
 		// Iterate to each row in the table contents
 		for (int index = 0; index < clientProfileData.size(); index++) {
@@ -278,7 +278,7 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
 			ArrayList<String> tableRow = new ArrayList<String>();
 			
 			for (Integer columnNumber : this.desiredColumnOrder){
-				tableRow.add( ((ArrayList<String>)clientProfileData.get(index)).get(columnNumber));
+				tableRow.add( (clientProfileData.get(index)).get(columnNumber));
 			}
 			
 			// Add the empty columns for computed values later on
@@ -297,9 +297,9 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
 		// Also remove the ones that have no configured username referencing it
 		// While iterating here, add the missing computed column values
 		
-		Iterator<Object> itr = clientProfileData.iterator();	
+		Iterator<ArrayList<String>> itr = clientProfileData.iterator();	
 		while (itr.hasNext()) {		
-			ArrayList<String> tempTableRow = (ArrayList<String>) itr.next();
+			ArrayList<String> tempTableRow = itr.next();
 			String cpName = tempTableRow.get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Client Profile"));
 			String vpnName = tempTableRow.get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Message VPN"));
 			int userCount = Integer.parseInt(tempTableRow.get(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Number of Users")));
@@ -316,8 +316,8 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
 					long nConnections = 
 							clientData
 							.stream()
-							.filter(tableRow -> vpnName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("message-vpn") )   ))
-							.filter(tableRow -> cpName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("profile") )   ))
+							.filter(tableRow -> vpnName.equalsIgnoreCase( tableRow.get( clientDataColumnNames.indexOf("message-vpn") )   ))
+							.filter(tableRow -> cpName.equalsIgnoreCase( tableRow.get( clientDataColumnNames.indexOf("profile") )   ))
 							.count();	
 					tempTableRow.set(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Connections - Current"), Long.toString(nConnections));
 					
@@ -325,9 +325,9 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
 					long nSubscriptions = 
 							clientData
 							.stream()
-							.filter(tableRow -> vpnName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("message-vpn") )   ))
-							.filter(tableRow -> cpName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("profile") )   ))
-							.map   (tableRow -> ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("num-subscriptions")  ) )	// Only that one column)
+							.filter(tableRow -> vpnName.equalsIgnoreCase( tableRow.get( clientDataColumnNames.indexOf("message-vpn") )   ))
+							.filter(tableRow -> cpName.equalsIgnoreCase( tableRow.get( clientDataColumnNames.indexOf("profile") )   ))
+							.map   (tableRow -> tableRow.get( clientDataColumnNames.indexOf("num-subscriptions")  ) )	// Only that one column)
 							.mapToLong(Long::parseLong)
 							.sum();	
 					tempTableRow.set(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Subscriptions - Current"), Long.toString(nSubscriptions));
@@ -336,9 +336,9 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
 					long nIngressFlows = 
 							clientData
 							.stream()
-							.filter(tableRow -> vpnName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("message-vpn") )   ))
-							.filter(tableRow -> cpName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("profile") )   ))
-							.map   (tableRow -> ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("total-ingress-flows")  ) )	// Only that one column)
+							.filter(tableRow -> vpnName.equalsIgnoreCase( tableRow.get( clientDataColumnNames.indexOf("message-vpn") )   ))
+							.filter(tableRow -> cpName.equalsIgnoreCase( tableRow.get( clientDataColumnNames.indexOf("profile") )   ))
+							.map   (tableRow -> tableRow.get( clientDataColumnNames.indexOf("total-ingress-flows")  ) )	// Only that one column)
 							.mapToLong(Long::parseLong)
 							.sum();	
 					tempTableRow.set(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Ingress Flows - Current"), Long.toString(nIngressFlows));
@@ -347,9 +347,9 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
 					long nEgressFlows = 
 							clientData
 							.stream()
-							.filter(tableRow -> vpnName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("message-vpn") )   ))
-							.filter(tableRow -> cpName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("profile") )   ))
-							.map   (tableRow -> ((ArrayList<String>)tableRow).get( clientDataColumnNames.indexOf("total-egress-flows")  ) )	// Only that one column)
+							.filter(tableRow -> vpnName.equalsIgnoreCase( tableRow.get( clientDataColumnNames.indexOf("message-vpn") )   ))
+							.filter(tableRow -> cpName.equalsIgnoreCase( tableRow.get( clientDataColumnNames.indexOf("profile") )   ))
+							.map   (tableRow -> tableRow.get( clientDataColumnNames.indexOf("total-egress-flows")  ) )	// Only that one column)
 							.mapToLong(Long::parseLong)
 							.sum();	
 					tempTableRow.set(CP_LIMITS_DATAVIEW_COLUMN_NAMES.indexOf("Egress Flows - Current"), Long.toString(nEgressFlows));
@@ -382,14 +382,14 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
 		headlines.put("Last Sample Time", lastSampleTime);
 		
 		// Sort the list by the utilisation score. Then also limit to the max row count if exceeding it...
-		clientProfileDataTemp = new Vector<Object>();
+		clientProfileDataTemp = new Vector<ArrayList<String>>();
 		
 		clientProfileDataTemp.addAll(
 				clientProfileData
 				.stream()
 				.sorted(new UtilisationComparator())	
 				.limit(maxRows)				// Then cut the rows at max limit
-				.collect(Collectors.toCollection(Vector<Object>::new))
+				.collect(Collectors.toCollection(Vector<ArrayList<String>>::new))
 				);
 		clientProfileData = clientProfileDataTemp;
 
@@ -403,7 +403,10 @@ public class ClientProfileLimitsMonitor extends BaseMonitor implements MonitorCo
     			View view = viewMap.get(viewIt.next());	
     			if (view.isActive()) {
 					view.setHeadlines(headlines);
-    				view.setTableContent(clientProfileData);
+					// The .setTableContent() method forces a Vector of Object!
+					Vector<Object> submitTable = new Vector<Object>();
+					submitTable.addAll(clientProfileData);
+    				view.setTableContent(submitTable);
     			}
     		}
     	}

--- a/src/com/solacesystems/solgeneos/custommonitors/ClientsSlowSubscribersMonitor.java
+++ b/src/com/solacesystems/solgeneos/custommonitors/ClientsSlowSubscribersMonitor.java
@@ -30,7 +30,7 @@ import com.solacesystems.solgeneos.solgeneosagent.monitor.View;
 public class ClientsSlowSubscribersMonitor extends BaseMonitor implements MonitorConstants {
   
 	// What version of the monitor?
-	static final public String MONITOR_VERSION = "1.0";
+	static final public String MONITOR_VERSION = "1.0.1";
 	
 	// The SEMP queries to execute:
     static final public String SHOW_CLIENTS_REQUEST = 
@@ -53,9 +53,9 @@ public class ClientsSlowSubscribersMonitor extends BaseMonitor implements Monito
     static final private  List<String> RESPONSE_ELEMENT_NAMES_IGNORE = Arrays.asList("");
        
     // Override the column names to more human friendly
-    static final private List<String> DATAVIEW_COLUMN_NAMES = 
+    static final private ArrayList<String> DATAVIEW_COLUMN_NAMES = new ArrayList<String>(
     		Arrays.asList("RowUID", "Client ID", "Message VPN", "Host Address", "Username", "Process Owner", "Process Uptime", "Description", "Platform", 
-    				"Subscriptions", "Eliding Enabled?", "Elided Topics");
+    				"Subscriptions", "Eliding Enabled?", "Elided Topics"));
     
     // What is the desired order of columns?
     private List<Integer> desiredColumnOrder;	// To be set later once actual response is seen for the first time
@@ -64,8 +64,8 @@ public class ClientsSlowSubscribersMonitor extends BaseMonitor implements Monito
     private ResponseHandler<SampleHttpSEMPResponse> responseHandler;
     private TargetedMultiRecordSEMPParser multiRecordParser;
 
-    private Vector<Object> tableContent;
-    private Vector<Object> tempTableContent;
+    private Vector<ArrayList<String>> tableContent;
+    private Vector<ArrayList<String>> tempTableContent;
     private LinkedHashMap<String, Object> globalHeadlines = new LinkedHashMap<String, Object>();
         
     /**
@@ -184,7 +184,7 @@ public class ClientsSlowSubscribersMonitor extends BaseMonitor implements Monito
 		headlines.put("Number of Slow Subscribers", tableContent.size());
 
 		// Rearrange the table into the column order we want
-		tempTableContent = new Vector<Object>();
+		tempTableContent = new Vector<ArrayList<String>>();
 		
 		// Iterate to each row in the table contents
 		for (int index = 0; index < tableContent.size(); index++) {
@@ -193,7 +193,7 @@ public class ClientsSlowSubscribersMonitor extends BaseMonitor implements Monito
 			ArrayList<String> tableRow = new ArrayList<String>();
 			
 			for (Integer columnNumber : this.desiredColumnOrder){
-				tableRow.add( ((ArrayList<String>)tableContent.get(index)).get(columnNumber));
+				tableRow.add( (tableContent.get(index)).get(columnNumber));
 			}
 			// Add the newly created row to reorderedTableContent
 			tempTableContent.add(tableRow); 
@@ -209,7 +209,10 @@ public class ClientsSlowSubscribersMonitor extends BaseMonitor implements Monito
     			View view = viewMap.get(viewIt.next());	
     			if (view.isActive()) {
     				view.setHeadlines(headlines);
-    				view.setTableContent(tableContent);
+    				// The .setTableContent() method forces a Vector of Object!
+					Vector<Object> submitTable = new Vector<Object>();
+					submitTable.addAll(tableContent);
+    				view.setTableContent(submitTable);
     			}
     		}
     	}

--- a/src/com/solacesystems/solgeneos/custommonitors/QueuesExMonitor.java
+++ b/src/com/solacesystems/solgeneos/custommonitors/QueuesExMonitor.java
@@ -26,6 +26,7 @@ import org.apache.http.params.HttpParams;
 import com.solacesystems.solgeneos.custommonitors.util.MonitorConstants;
 import com.solacesystems.solgeneos.custommonitors.util.SampleHttpSEMPResponse;
 import com.solacesystems.solgeneos.custommonitors.util.SampleResponseHandler;
+import com.solacesystems.solgeneos.custommonitors.util.SampleSEMPParser;
 import com.solacesystems.solgeneos.custommonitors.util.TargetedMultiRecordSEMPParser;
 import com.solacesystems.solgeneos.solgeneosagent.SolGeneosAgent;
 import com.solacesystems.solgeneos.solgeneosagent.UserPropertiesConfig;
@@ -35,10 +36,10 @@ import com.solacesystems.solgeneos.solgeneosagent.monitor.View;
 public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
   
 	// What version of the monitor?
-	static final public String MONITOR_VERSION = "1.0.1";
+	static final public String MONITOR_VERSION = "1.1.0";
 	
 	// The SEMP query to execute:
-    static final public String SHOW_USERS_REQUEST = 
+    static final public String SHOW_QUEUES_REQUEST = 
             "<rpc>" + 
             "	<show>" +
             "		<queue>" +
@@ -57,42 +58,42 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
     				"total-delivered-unacked-msgs", "max-redelivery", "oldest-msg-id", "newest-msg-id", "bind-count", "max-bind-count", "dead-message-queue");
     // NOTE: "RowUID" is not expected in the SEMP response, but will be added by the parser. However adding it here allows this list to be used as an index where the column number can be searched by name
     
-    static final private  List<String> RESPONSE_ELEMENT_NAMES_IGNORE = Arrays.asList("event", "clients");
-     
-    // When fixing the response for the disjointed table due to some columns not always being present for some rows, which are those to shift it up?
-    static final private List<Integer> RESPONSE_PAD_COLUMN_NUMBERS = Arrays.asList(
-    		RESPONSE_COLUMNS.indexOf("oldest-msg-id"),
-    		RESPONSE_COLUMNS.indexOf("newest-msg-id")); 
+    // For SEMP rows nested a further level into the response, what is of interest?
+    static final private String RESPONSE_ELEMENT_NAME_ROWS_L2 = "clients";
+    static final private  List<String> RESPONSE_COLUMNS_L2 = 
+    		Arrays.asList("name", "is-active", "window-size", "connect-time", "flow-id", "last-msg-id-delivered");
+    
+    static final private  List<String> RESPONSE_ELEMENT_NAMES_IGNORE = Arrays.asList("event"); 
     
     // When pretty printing numbers, which columns should be formatted? 
-    static final private List<Integer> RESPONSE_NUMBER_FORMAT_COLUMN_NUMBERS = Arrays.asList(
-    		RESPONSE_COLUMNS.indexOf("current-spool-usage-in-mb"), 
-    		RESPONSE_COLUMNS.indexOf("high-water-mark-in-mb")); 	
+    static final private List<String> RESPONSE_NUMBER_FORMAT_COLUMNS = Arrays.asList(
+    		"Spool Usage (MB)", "Spool Usage HWM (MB)"); 	
     
     // What should be the formatting style?
     static final private String FLOAT_FORMAT_STYLE = "%.2f";	// 2 decimal places
-    		
-    // What is the desired order of columns?
-    static final private List<Integer> DESIRED_COLUMN_ORDER = Arrays.asList(
-    		RESPONSE_COLUMNS.indexOf("RowUID"), RESPONSE_COLUMNS.indexOf("name"), RESPONSE_COLUMNS.indexOf("message-vpn"),
-    		RESPONSE_COLUMNS.indexOf("num-messages-spooled"), RESPONSE_COLUMNS.indexOf("current-spool-usage-in-mb"), RESPONSE_COLUMNS.indexOf("quota"), RESPONSE_COLUMNS.indexOf("high-water-mark-in-mb"),
-    		RESPONSE_COLUMNS.indexOf("total-delivered-unacked-msgs"), RESPONSE_COLUMNS.indexOf("bind-count"), RESPONSE_COLUMNS.indexOf("max-bind-count"), RESPONSE_COLUMNS.indexOf("access-type"),
-    		RESPONSE_COLUMNS.indexOf("durable"), RESPONSE_COLUMNS.indexOf("owner"), RESPONSE_COLUMNS.indexOf("ingress-config-status"), RESPONSE_COLUMNS.indexOf("egress-config-status"),
-    		RESPONSE_COLUMNS.indexOf("oldest-msg-id"), RESPONSE_COLUMNS.indexOf("newest-msg-id"), RESPONSE_COLUMNS.indexOf("respect-ttl"), RESPONSE_COLUMNS.indexOf("max-ttl"), 
-    		RESPONSE_COLUMNS.indexOf("reject-msg-to-sender-on-discard"), RESPONSE_COLUMNS.indexOf("max-redelivery"), RESPONSE_COLUMNS.indexOf("dead-message-queue"));
+    
+    // What is the desired order of columns? (Will be set after first getting a response)
+    private List<Integer> desiredColumnOrder;
+    
+    // When fixing the response for the disjointed table due to msg-id columns not always being present for some rows, which are those to shift it up?
+    static final private List<String> RESPONSE_OPTIONAL_COLUMNS = Arrays.asList(
+    		"oldest-msg-id", "newest-msg-id"); 
+    
     // Override the column names to more human friendly
-    static final private List<String> COLUMN_NAME_OVERRIDE = 
+    static final private ArrayList<String> COLUMN_NAME_OVERRIDE = new ArrayList<String>(
     		Arrays.asList("RowUID", "Queue Name", "Message VPN", "Messages Spooled", "Spool Usage (MB)", "Spool Quota (MB)", "Spool Usage HWM (MB)", 
     				"Delivered Messages Unacked", "Bind Count", "Bind Count - Max", "Access Type",
     				"Durable", "Owner", "Ingress Status", "Egress Status",
     				"Oldest Msg ID", "Newest Msg ID", "Respect TTL", "Max TTL",
-    				"Reject to Sender on Discard", "Max Redelivery Attempts", "Dead Message Queue");
+    				"Reject to Sender on Discard", "Max Redelivery Attempts", "Dead Message Queue",
+    				"Client ID", "Is Active?", "Window Size", "Connect Time", "Flow ID", "Last Msg ID Delivered", 
+    				"Last Seen Client ID", "Last Seen Connect Time"));
     
     private DefaultHttpClient httpClient;
     private ResponseHandler<SampleHttpSEMPResponse> responseHandler;
     private TargetedMultiRecordSEMPParser multiRecordParser;
 
-    private Vector<Object> receivedTableContent;
+    private Vector<ArrayList<String>> receivedTableContent;
     
     private LinkedHashMap<String, Object> globalHeadlines = new LinkedHashMap<String, Object>();
     // Is the monitor creating a dataview per VPN or everything is in one view?
@@ -104,7 +105,7 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
     private List<String> detectedVpns;
     
     // A map of per view table contents and headlines
-    private Map<String, Vector<Object>> tablesPerView = new HashMap<String, Vector<Object>>();
+    private Map<String, Vector<ArrayList<String>>> tablesPerView = new HashMap<String, Vector<ArrayList<String>>>();
     private Map<String, LinkedHashMap<String, Object>> headlinesPerView = new HashMap<String, LinkedHashMap<String, Object>>();
     
     // If multi-view mode and a view is to be deleted, cannot delete and clear it in one update. So need two samples for this, marking it for delete on the first sample.
@@ -125,15 +126,28 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
         @SuppressWarnings("unchecked")
 		public int compare(Object tableRow1, Object tableRow2)
         {
-        	double spoolUsage1 = Double.parseDouble( ((ArrayList<String>)tableRow1).get( RESPONSE_COLUMNS.indexOf("current-spool-usage-in-mb") ));
-        	double spoolQuota1 = Double.parseDouble( ((ArrayList<String>)tableRow1).get( RESPONSE_COLUMNS.indexOf("quota") ));
+        	double spoolUsage1 = Double.parseDouble( ((ArrayList<String>)tableRow1).get( COLUMN_NAME_OVERRIDE.indexOf("Spool Usage (MB)") ));
+        	double spoolQuota1 = Double.parseDouble( ((ArrayList<String>)tableRow1).get( COLUMN_NAME_OVERRIDE.indexOf("Spool Quota (MB)") ));
         	double utilisation1 = (spoolQuota1 > 0) ? (spoolUsage1 / spoolQuota1) * 100 : 0;
 
-        	double spoolUsage2 = Double.parseDouble( ((ArrayList<String>)tableRow2).get( RESPONSE_COLUMNS.indexOf("current-spool-usage-in-mb") ));
-        	double spoolQuota2 = Double.parseDouble( ((ArrayList<String>)tableRow2).get( RESPONSE_COLUMNS.indexOf("quota") ));
+        	double spoolUsage2 = Double.parseDouble( ((ArrayList<String>)tableRow2).get( COLUMN_NAME_OVERRIDE.indexOf("Spool Usage (MB)") ));
+        	double spoolQuota2 = Double.parseDouble( ((ArrayList<String>)tableRow2).get( COLUMN_NAME_OVERRIDE.indexOf("Spool Quota (MB)") ));
         	double utilisation2 = (spoolQuota2 > 0) ? (spoolUsage2 / spoolQuota2) * 100 : 0;
 
             return Double.compare(utilisation2, utilisation1);	
+        }
+    }
+    
+    // For connected clients of non-exclusive queues, how to sort the flow ID to only show the first entry?
+    static class FlowIDComparator implements Comparator<Object>
+    {
+        @SuppressWarnings("unchecked")
+		public int compare(Object tableRow1, Object tableRow2)
+        {
+        	long flowID1 = Long.parseLong( ((ArrayList<String>)tableRow1).get( RESPONSE_COLUMNS_L2.indexOf("flow-id") ));
+        	long flowID2 = Long.parseLong( ((ArrayList<String>)tableRow2).get( RESPONSE_COLUMNS_L2.indexOf("flow-id") ));
+        	
+        	return Long.compare(flowID1, flowID2);	
         }
     }
     
@@ -223,11 +237,42 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 	    // associated resources
         responseHandler = new SampleResponseHandler();
         
-        // create SEMP parser with the name of the element that contains the records
-		multiRecordParser = new TargetedMultiRecordSEMPParser(RESPONSE_ELEMENT_NAME_ROWS, RESPONSE_COLUMNS, RESPONSE_ELEMENT_NAMES_IGNORE);
+        // create SEMP parser with the name of the element that contains the records, and the element name for nested level 2 records
+		multiRecordParser = new TargetedMultiRecordSEMPParser(
+				RESPONSE_ELEMENT_NAME_ROWS, RESPONSE_COLUMNS, RESPONSE_ELEMENT_NAMES_IGNORE, 
+				RESPONSE_ELEMENT_NAME_ROWS_L2, RESPONSE_COLUMNS_L2);
 		
 	}
-        
+	
+	private void setDesiredColumnOrder (List<String> currentColumnNames) {
+	    
+		desiredColumnOrder = Arrays.asList(
+				currentColumnNames.indexOf("RowUID"), currentColumnNames.indexOf("name"), currentColumnNames.indexOf("message-vpn"),
+				currentColumnNames.indexOf("num-messages-spooled"), currentColumnNames.indexOf("current-spool-usage-in-mb"), currentColumnNames.indexOf("quota"), currentColumnNames.indexOf("high-water-mark-in-mb"),
+				currentColumnNames.indexOf("total-delivered-unacked-msgs"), currentColumnNames.indexOf("bind-count"), currentColumnNames.indexOf("max-bind-count"), currentColumnNames.indexOf("access-type"),
+				currentColumnNames.indexOf("durable"), currentColumnNames.indexOf("owner"), currentColumnNames.indexOf("ingress-config-status"), currentColumnNames.indexOf("egress-config-status"),
+				currentColumnNames.indexOf("oldest-msg-id"), currentColumnNames.indexOf("newest-msg-id"), currentColumnNames.indexOf("respect-ttl"), currentColumnNames.indexOf("max-ttl"), 
+				currentColumnNames.indexOf("reject-msg-to-sender-on-discard"), currentColumnNames.indexOf("max-redelivery"), currentColumnNames.indexOf("dead-message-queue")
+		);
+	}
+
+	private void submitSEMPQuery (String sempQuery, SampleSEMPParser sempParser) throws Exception {
+		
+		// Get the first SEMP query response...
+		HttpPost post = new HttpPost(HTTP_REQUEST_URI);
+		post.setHeader(HEADER_CONTENT_TYPE_UTF8);
+		post.setEntity(new ByteArrayEntity(sempQuery.getBytes("UTF-8")));
+		
+		
+		SampleHttpSEMPResponse resp = httpClient.execute(post, responseHandler);
+        if (resp.getStatusCode() != 200) {
+        	throw new Exception("Error occurred while sending request: " + resp.getStatusCode() 
+        			+ " - " + resp.getReasonPhrase());
+        }	        
+        String respBody = resp.getRespBody();        
+        sempParser.parse(respBody);
+	}
+	
 	/**
 	 * This method is responsible to collect data required for a view.
 	 * @return The next monitor state which should be State.REPORTING_QUEUE.
@@ -240,56 +285,72 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 		TreeMap<String, View> viewMap = getViewMap();
 		LinkedHashMap<String, Object> headlines;
 		
-		// Construct table content
-		HttpPost post = new HttpPost(HTTP_REQUEST_URI);
-		post.setHeader(HEADER_CONTENT_TYPE_UTF8);
-		post.setEntity(new ByteArrayEntity(SHOW_USERS_REQUEST.getBytes("UTF-8")));
+		submitSEMPQuery(SHOW_QUEUES_REQUEST, multiRecordParser);
 		
-		
-		SampleHttpSEMPResponse resp = httpClient.execute(post, responseHandler);
-		
-        if (resp.getStatusCode() != 200) {
-
-        	throw new Exception("Error occurred while sending request: " + resp.getStatusCode() 
-        			+ " - " + resp.getReasonPhrase());
-        }	        
-        String respBody = resp.getRespBody();        
-		multiRecordParser.parse(respBody);
-		
-		
+		List<String> currentColumnNames = multiRecordParser.getColumnNames();
+				
 		// Will take what is received as the table contents and then do further Java8 Streams based filtering... 
-		this.receivedTableContent = multiRecordParser.getTableContent();
-		
+		receivedTableContent = multiRecordParser.getTableContent();
 		
 		// Need to do some cleanup on the received table as two optional output fields cause some disjointed column alignment
-		Vector<Object> goodTableContent = new Vector<Object>();
-		Vector<Object> brokenTableContent = new Vector<Object>();
+		Vector<ArrayList<String>> goodTableContent = new Vector<ArrayList<String>>();
+		Vector<ArrayList<String>> brokenTableContent = new Vector<ArrayList<String>>();
 
-		// To detect that, the expected number of columns is the column names list size if everything got provided
-		
+		// To detect that, the expected number of columns is the column names list size if everything got provided		
 		goodTableContent.addAll(
 				receivedTableContent
 				.stream()
-				.filter( tableRow -> ((ArrayList<String>)tableRow).size() == RESPONSE_COLUMNS.size())
-				.collect(Collectors.toCollection(Vector<Object>::new))
+				.filter( tableRow -> tableRow.size() == RESPONSE_COLUMNS.size())
+				.collect(Collectors.toCollection(Vector<ArrayList<String>>::new))
 			);
-				
+		
 		brokenTableContent.addAll(
 				receivedTableContent
 				.stream()
-				.filter( tableRow -> ((ArrayList<String>)tableRow).size() == (RESPONSE_COLUMNS.size() - RESPONSE_PAD_COLUMN_NUMBERS.size()))
-				.collect(Collectors.toCollection(Vector<Object>::new))
+				.filter( tableRow -> tableRow.size() == (RESPONSE_COLUMNS.size() - RESPONSE_OPTIONAL_COLUMNS.size()))
+				.collect(Collectors.toCollection(Vector<ArrayList<String>>::new))
 			);
 		
-		// For the rows in the broken table, fix it by padding where necessary
-	    for (Integer columnNumberToPad : RESPONSE_PAD_COLUMN_NUMBERS) 
-	    { 		      
-			brokenTableContent.forEach(tableRow -> ((ArrayList<String>)tableRow).add(columnNumberToPad, ""));
-	    }
+		// For the rows in the broken table, fix it by padding into the correct column position
+		// Note: Columns in the original response order still
+		
+		// First add the optional column names if missing from current response columns even
+		if (currentColumnNames.indexOf(RESPONSE_OPTIONAL_COLUMNS.get(0)) < 0) {
+			for (String optionalColumn : RESPONSE_OPTIONAL_COLUMNS) {
+				currentColumnNames.add(optionalColumn);	
+			}
+		}
+		
+		// Because of the optional columns being present or not changing between polls, need to set the column order each time:
+		setDesiredColumnOrder(currentColumnNames);	
+				
+		for (String optionalColumn : RESPONSE_OPTIONAL_COLUMNS) {			
+			brokenTableContent.forEach(tableRow -> tableRow.add(currentColumnNames.indexOf(optionalColumn), ""));	
+		}
 	    
 		// Merge it all together now...
 		goodTableContent.addAll(brokenTableContent);
-
+		
+		// Reorder the merged table into the column order we want. 
+		Vector<ArrayList<String>> tempVpnLimitsTableContent = new Vector<ArrayList<String>>();
+		
+		// Iterate to each row in the table contents
+		for (int index = 0; index < goodTableContent.size(); index++) {
+			
+			// Build a new tableRow by adding to it in the right order 
+			ArrayList<String> tableRow = new ArrayList<String>();
+			
+			for (Integer columnNumber : this.desiredColumnOrder){
+				tableRow.add( goodTableContent.get(index).get(columnNumber));
+			}
+			// Add the newly created row to reorderedTableContent
+			tempVpnLimitsTableContent.add(tableRow); 
+		} 
+		goodTableContent = tempVpnLimitsTableContent;
+		
+		// NOTE: Table has been reordered from this point onwards. No further references to 'desiredColumnOrder' for column lookups
+		// All lookups should be based off 'COLUMN_NAME_OVERRIDE' and the user friendly column names, not the SEMP field name.
+		
 	    // If connected to the broker that is in Active-Standby Role of 'Standby', several other columns are missing in the response. e.g. bind-count.
 	    // This situation can be detected if the received table content was non-zero, yet the final 'good' table content is empty.
 		// Create a message to explain this in the dataview, instructing the user to view the broker in the 'Active' role instead.
@@ -298,7 +359,7 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 		isStandbyBrokerBefore = (isStandbyBrokerBefore == -1) ? isStandbyBrokerNow : isStandbyBrokerBefore;
 				
 		// Reset any previously saved table state
-		tablesPerView = new HashMap<String, Vector<Object>>();		
+		tablesPerView = new HashMap<String, Vector<ArrayList<String>>>();		
 	
 		// Split into per-VPN datasets if split mode selected
 		if (multiview)
@@ -309,7 +370,7 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 			detectedVpns.addAll(
 				goodTableContent
 				.stream()
-				.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("message-vpn") ) )
+				.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Message VPN") ) )
 				.distinct()
 				.collect(Collectors.toCollection(ArrayList<String>::new))
 				);
@@ -332,8 +393,8 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 				tablesPerView.put(vpnName, 
 						goodTableContent
 						.stream()
-						.filter(tableRow -> vpnName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("message-vpn") )    ) )
-						.collect(Collectors.toCollection(Vector<Object>::new))
+						.filter(tableRow -> vpnName.equalsIgnoreCase( tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Message VPN") )    ) )
+						.collect(Collectors.toCollection(Vector<ArrayList<String>>::new))
 					);	
 			}
 						
@@ -363,7 +424,7 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 				long queuesWithMsgs = 
 						goodTableContent
 						.stream()
-						.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("num-messages-spooled") ) )	// Only num-messages-spooled column
+						.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Messages Spooled") ) )	// Only num-messages-spooled column
 						.mapToInt(Integer::parseInt)
 						.filter(x -> x > 0) 		// Only the non-zero entries
 						.count() ;
@@ -371,7 +432,7 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 				long queuesWithBinds = 
 						goodTableContent
 						.stream()
-						.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("bind-count") ) )	// Only bind-count column
+						.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Bind Count") ) )	// Only bind-count column
 						.mapToInt(Integer::parseInt)
 						.filter(x -> x > 0) 		// Only the non-zero entries
 						.count() ;
@@ -379,7 +440,7 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 				long queuesWithZeroBinds = 
 						goodTableContent
 						.stream()
-						.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("bind-count") ) )	// Only bind-count column
+						.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Bind Count") ) )	// Only bind-count column
 						.mapToInt(Integer::parseInt)
 						.filter(x -> x == 0) 		// Only the non-zero entries
 						.count() ;
@@ -387,14 +448,14 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 				long sumQueuedMsgs = 
 						goodTableContent
 						.stream()
-						.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("num-messages-spooled") ) )	// Only num-messages-spooled column
+						.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Messages Spooled") ) )	// Only num-messages-spooled column
 						.mapToLong(Long::parseLong) 	
 						.sum() ;
 				
 				double sumSpoolUsage = 
 						goodTableContent
 						.stream()
-						.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("current-spool-usage-in-mb") ) )	// Only current-spool-usage-in-mb column
+						.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Spool Usage (MB)") ) )	// Only current-spool-usage-in-mb column
 						.mapToDouble(Double::parseDouble)	
 						.sum() ;
 				
@@ -407,50 +468,117 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 				headlines.put("Total Queues Count", goodTableContent.size());
 				
 				// Sort the list to show entries needing attention near to the top. Then also limit to the max row count if exceeding it...
-				Vector<Object> tempTableContent = new Vector<Object>();
+				Vector<ArrayList<String>> tempTableContent = new Vector<ArrayList<String>>();
+				Vector<ArrayList<String>> tempTableContentClients;
 				
 				tempTableContent.addAll(
 						goodTableContent
 						.stream()
 						.sorted(new QueuesComparator())
 						.limit(maxRows)				// Then cut the rows at max limit
-						.collect(Collectors.toCollection(Vector<Object>::new))
+						.collect(Collectors.toCollection(Vector<ArrayList<String>>::new))
 						);
 				
 				goodTableContent = tempTableContent;
 				
 				// Pretty up the MB usage numbers. Get the value, format it, set it back. NOTE: Do it as close to the final step towards publishing the table
-			    for (Integer columnNumberToFormat : RESPONSE_NUMBER_FORMAT_COLUMN_NUMBERS) 
+			    for (String columnToNumberFormat : RESPONSE_NUMBER_FORMAT_COLUMNS) 
 			    { 		      
-			    	goodTableContent.forEach(tableRow -> ((ArrayList<String>)tableRow)
-			    			.set(columnNumberToFormat, 
+			    	goodTableContent.forEach(tableRow -> tableRow
+			    			.set(COLUMN_NAME_OVERRIDE.indexOf(columnToNumberFormat), 
 			    					String.format(FLOAT_FORMAT_STYLE, 
 			    							Double.parseDouble(
-			    									((ArrayList<String>)tableRow).get(columnNumberToFormat)
+			    									tableRow.get(COLUMN_NAME_OVERRIDE.indexOf(columnToNumberFormat))
 			    									)
 			    							) 
 			    					)
 							);	
 			    }
-			    
-				// Finally, reorder data into the column order we want versus what came from the parser
-				Vector<Object> reorderedTableContent = new Vector<Object>();
-				// Iterate to each row in the table contents
+			   				
+				// Finally, for the final list of queues, annotate with extra columns with details of the bound consumer only if bind-count=1
+				tempTableContent = new Vector<ArrayList<String>>();
+				List<String> tempL2ColumnNames;
+				String rowUID;
+				
 				for (int index = 0; index < goodTableContent.size(); index++) {
 					
-					// Build a new tableRow by adding to it in the right order 
-					ArrayList<String> tableRow = new ArrayList<String>();
-					
-					for (Integer columnNumber : this.DESIRED_COLUMN_ORDER){
-						tableRow.add( ((ArrayList<String>)goodTableContent.get(index)).get(columnNumber));
+					// Build a new tableRow by adding to it with necessary annotations 
+					ArrayList<String> tableRow = goodTableContent.get(index);
+					String bindCount = tableRow.get(COLUMN_NAME_OVERRIDE.indexOf("Bind Count"));
+					String accessType = tableRow.get(COLUMN_NAME_OVERRIDE.indexOf("Access Type"));
+										
+					String clientID = "";
+					String isActive = "";
+					String windowSize = "";
+					String connectTime = "";
+					String flowID = "";
+					String lastMsgIDDelivered = "";
+					// These last two will stay empty fields since geneos rules populate them, not this monitor directly
+					String lastSeenClientID = "";
+					String lastSeenConnectTime = "";
+				
+					if (!bindCount.equalsIgnoreCase("0")) {
+						rowUID = tableRow.get(COLUMN_NAME_OVERRIDE.indexOf("RowUID"));
+						tempL2ColumnNames = multiRecordParser.getColumnNamesLevel2();
+						tempTableContentClients = multiRecordParser.getTableContentLevel2(rowUID);
+						
+						if (tempTableContentClients.size() > 0) {
+							
+							// Which client to show in a single line available?
+							// If exclusive mode, show the one that is Active-Consumer
+							// If non-exclusive mode, show the lowest flow id?
+							
+							ArrayList<String> tableRowClient;
+							
+							if (bindCount.equalsIgnoreCase("1")) {
+								// Just one bind, so first (and only) entry in the table
+								tableRowClient = tempTableContentClients.get(0);
+							}
+							else {
+								// Bit more complicated, several to pick from but need to be deterministic between polls
+								if (accessType.equalsIgnoreCase("exclusive")) {
+									// Get the client that is active consuming
+									tableRowClient = tempTableContentClients
+											.stream()
+											.filter(x -> x.get(RESPONSE_COLUMNS_L2.indexOf("is-active")).equalsIgnoreCase("Active-Consumer"))
+											.limit(1)
+											.collect(Collectors.toList()).get(0);
+								}
+								else {
+									// Get the lowest flow ID (so earliest connected) of the set
+									tableRowClient = tempTableContentClients
+											.stream()
+											.sorted(new FlowIDComparator())
+											.limit(1)
+											.collect(Collectors.toList()).get(0);
+								}
+							}
+														
+							clientID = tableRowClient.get(tempL2ColumnNames.indexOf("name"));
+							isActive = tableRowClient.get(tempL2ColumnNames.indexOf("is-active"));
+							windowSize = tableRowClient.get(tempL2ColumnNames.indexOf("window-size"));
+							connectTime = tableRowClient.get(tempL2ColumnNames.indexOf("connect-time"));
+							flowID = tableRowClient.get(tempL2ColumnNames.indexOf("flow-id"));
+							lastMsgIDDelivered = tableRowClient.get(tempL2ColumnNames.indexOf("last-msg-id-delivered"));
+						}
 					}
-					// Add the newly created row to reorderedTableContent
-					reorderedTableContent.add(tableRow); 
+					tableRow.add(clientID);
+					tableRow.add(isActive);
+					tableRow.add(windowSize);
+					tableRow.add(connectTime);
+					tableRow.add(flowID);
+					tableRow.add(lastMsgIDDelivered);
+					tableRow.add(lastSeenClientID);
+					tableRow.add(lastSeenConnectTime);
+					
+					// Add the newly created row to tempTableContent
+					tempTableContent.add(tableRow); 
 				}  
+				goodTableContent = tempTableContent;
 				
 				// Table content all complete now for publishing. Just add the column names too.
-				reorderedTableContent.add(0, this.COLUMN_NAME_OVERRIDE);	// No longer as received from parser in receivedColumnNames
-				tablesPerView.put(viewKey, reorderedTableContent);
+				goodTableContent.add(0, this.COLUMN_NAME_OVERRIDE);	// No longer as received from parser in receivedColumnNames
+				tablesPerView.put(viewKey, goodTableContent);
 				headlinesPerView.put(viewKey, headlines);
 			}
 			else
@@ -458,7 +586,7 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
 				// There is no content for this view, either no endpoints in the VPN, or its a Standby role broker
 				// If Standby broker, add a message to signal this clearly
 				if (isStandbyBrokerNow == 1) {
-					Vector<Object> messageTableContent = new Vector<Object>();
+					Vector<ArrayList<String>> messageTableContent = new Vector<ArrayList<String>>();
 					ArrayList<String> tableRow; 
 					
 					tableRow = new ArrayList<String>();
@@ -494,9 +622,13 @@ public class QueuesExMonitor extends BaseMonitor implements MonitorConstants {
         					view.setReset(true);
         					isStandbyBrokerBefore = isStandbyBrokerNow;
     					}
-    					//view.setSampler("SolaceSampler-Client");
+
     					view.setHeadlines(headlinesPerView.get(view.getName()));
-        				view.setTableContent(tablesPerView.get(view.getName()));
+    					
+    					// The .setTableContent() method forces a Vector of Object!
+    					Vector<Object> submitTable = new Vector<Object>();
+    					submitTable.addAll(tablesPerView.get(view.getName()));
+        				view.setTableContent(submitTable);
     				}
     				else
     				{

--- a/src/com/solacesystems/solgeneos/custommonitors/TopicEndpointsExMonitor.java
+++ b/src/com/solacesystems/solgeneos/custommonitors/TopicEndpointsExMonitor.java
@@ -23,9 +23,11 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.params.HttpParams;
 
+import com.solacesystems.solgeneos.custommonitors.QueuesExMonitor.FlowIDComparator;
 import com.solacesystems.solgeneos.custommonitors.util.MonitorConstants;
 import com.solacesystems.solgeneos.custommonitors.util.SampleHttpSEMPResponse;
 import com.solacesystems.solgeneos.custommonitors.util.SampleResponseHandler;
+import com.solacesystems.solgeneos.custommonitors.util.SampleSEMPParser;
 import com.solacesystems.solgeneos.custommonitors.util.TargetedMultiRecordSEMPParser;
 import com.solacesystems.solgeneos.solgeneosagent.SolGeneosAgent;
 import com.solacesystems.solgeneos.solgeneosagent.UserPropertiesConfig;
@@ -35,10 +37,10 @@ import com.solacesystems.solgeneos.solgeneosagent.monitor.View;
 public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConstants {
   
 	// What version of the monitor?
-	static final public String MONITOR_VERSION = "1.0.1";
+	static final public String MONITOR_VERSION = "1.1.0";
 	
 	// The SEMP query to execute:
-    static final public String SHOW_USERS_REQUEST = 
+    static final public String SHOW_TES_REQUEST = 
             "<rpc>" + 
             "	<show>" +
             "		<topic-endpoint>" +
@@ -56,43 +58,43 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
     				"respect-ttl", "max-ttl", "reject-msg-to-sender-on-discard", "num-messages-spooled", "current-spool-usage-in-mb", "high-water-mark-in-mb", 
     				"total-delivered-unacked-msgs", "max-redelivery", "oldest-msg-id", "newest-msg-id", "bind-count", "max-bind-count", "dead-message-queue");
     // NOTE: "RowUID" is not expected in the SEMP response, but will be added by the parser. However adding it here allows this list to be used as an index where the column number can be searched by name
+         
+    // For SEMP rows nested a further level into the response, what is of interest?
+    static final private String RESPONSE_ELEMENT_NAME_ROWS_L2 = "clients";
+    static final private  List<String> RESPONSE_COLUMNS_L2 = 
+    		Arrays.asList("name", "is-active", "window-size", "connect-time", "flow-id", "last-msg-id-delivered");
     
-    static final private  List<String> RESPONSE_ELEMENT_NAMES_IGNORE = Arrays.asList("event", "clients");
-     
-    // When fixing the response for the disjointed table due to msg-id columns not always being present for some rows, which are those to shift it up?
-    static final private List<Integer> RESPONSE_PAD_COLUMN_NUMBERS = Arrays.asList(
-    		RESPONSE_COLUMNS.indexOf("oldest-msg-id"),
-    		RESPONSE_COLUMNS.indexOf("newest-msg-id")); 
-    
+    static final private  List<String> RESPONSE_ELEMENT_NAMES_IGNORE = Arrays.asList("event");
+
     // When pretty printing numbers, which columns should be formatted? 
-    static final private List<Integer> RESPONSE_NUMBER_FORMAT_COLUMN_NUMBERS = Arrays.asList(
-    		RESPONSE_COLUMNS.indexOf("current-spool-usage-in-mb"), 
-    		RESPONSE_COLUMNS.indexOf("high-water-mark-in-mb")); 	
+    static final private List<String> RESPONSE_NUMBER_FORMAT_COLUMNS = Arrays.asList(
+    		"Spool Usage (MB)", "Spool Usage HWM (MB)"); 	
     
     // What should be the formatting style?
     static final private String FLOAT_FORMAT_STYLE = "%.2f";	// 2 decimal places
-    		
-    // What is the desired order of columns?
-    static final private List<Integer> DESIRED_COLUMN_ORDER = Arrays.asList(
-    		RESPONSE_COLUMNS.indexOf("RowUID"), RESPONSE_COLUMNS.indexOf("name"), RESPONSE_COLUMNS.indexOf("message-vpn"),
-    		RESPONSE_COLUMNS.indexOf("num-messages-spooled"), RESPONSE_COLUMNS.indexOf("current-spool-usage-in-mb"), RESPONSE_COLUMNS.indexOf("quota"), RESPONSE_COLUMNS.indexOf("high-water-mark-in-mb"),
-    		RESPONSE_COLUMNS.indexOf("total-delivered-unacked-msgs"), RESPONSE_COLUMNS.indexOf("bind-count"), RESPONSE_COLUMNS.indexOf("max-bind-count"), RESPONSE_COLUMNS.indexOf("access-type"), RESPONSE_COLUMNS.indexOf("destination"),
-    		RESPONSE_COLUMNS.indexOf("durable"), RESPONSE_COLUMNS.indexOf("owner"), RESPONSE_COLUMNS.indexOf("ingress-config-status"), RESPONSE_COLUMNS.indexOf("egress-config-status"),
-    		RESPONSE_COLUMNS.indexOf("oldest-msg-id"), RESPONSE_COLUMNS.indexOf("newest-msg-id"), RESPONSE_COLUMNS.indexOf("respect-ttl"), RESPONSE_COLUMNS.indexOf("max-ttl"), 
-    		RESPONSE_COLUMNS.indexOf("reject-msg-to-sender-on-discard"), RESPONSE_COLUMNS.indexOf("max-redelivery"), RESPONSE_COLUMNS.indexOf("dead-message-queue"));
+    
+    // What is the desired order of columns? (Will be set after first getting a response)
+    private List<Integer> desiredColumnOrder;
+    
+    // When fixing the response for the disjointed table due to msg-id columns not always being present for some rows, which are those to shift it up?
+    static final private List<String> RESPONSE_OPTIONAL_COLUMNS = Arrays.asList(
+    		"oldest-msg-id", "newest-msg-id"); 
+    
     // Override the column names to more human friendly
-    static final private List<String> COLUMN_NAME_OVERRIDE = 
+    static final private ArrayList<String> COLUMN_NAME_OVERRIDE = new ArrayList<String>( 
     		Arrays.asList("RowUID", "TopicEndpoint Name", "Message VPN", "Messages Spooled", "Spool Usage (MB)", "Spool Quota (MB)", "Spool Usage HWM (MB)", 
     				"Delivered Messages Unacked", "Bind Count", "Bind Count - Max", "Access Type", "Subscription",
     				"Durable", "Owner", "Ingress Status", "Egress Status",
     				"Oldest Msg ID", "Newest Msg ID", "Respect TTL", "Max TTL",
-    				"Reject to Sender on Discard", "Max Redelivery Attempts", "Dead Message Queue");
+    				"Reject to Sender on Discard", "Max Redelivery Attempts", "Dead Message Queue",
+    				"Client ID", "Is Active?", "Window Size", "Connect Time", "Flow ID", "Last Msg ID Delivered", 
+    				"Last Seen Client ID", "Last Seen Connect Time"));
     
     private DefaultHttpClient httpClient;
     private ResponseHandler<SampleHttpSEMPResponse> responseHandler;
     private TargetedMultiRecordSEMPParser multiRecordParser;
 
-    private Vector<Object> receivedTableContent;
+    private Vector<ArrayList<String>> receivedTableContent;
     
     private LinkedHashMap<String, Object> globalHeadlines = new LinkedHashMap<String, Object>();
     // Is the monitor creating a dataview per VPN or everything is in one view?
@@ -104,7 +106,7 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
     private List<String> detectedVpns;
     
     // A map of per view table contents and headlines
-    private Map<String, Vector<Object>> tablesPerView = new HashMap<String, Vector<Object>>();
+    private Map<String, Vector<ArrayList<String>>> tablesPerView = new HashMap<String, Vector<ArrayList<String>>>();
     private Map<String, LinkedHashMap<String, Object>> headlinesPerView = new HashMap<String, LinkedHashMap<String, Object>>();
     
     // If multi-view mode and a view is to be deleted, cannot delete and clear it in one update. So need two samples for this, marking it for delete on the first sample.
@@ -125,18 +127,30 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
         @SuppressWarnings("unchecked")
 		public int compare(Object tableRow1, Object tableRow2)
         {
-        	double spoolUsage1 = Double.parseDouble( ((ArrayList<String>)tableRow1).get( RESPONSE_COLUMNS.indexOf("current-spool-usage-in-mb") ));
-        	double spoolQuota1 = Double.parseDouble( ((ArrayList<String>)tableRow1).get( RESPONSE_COLUMNS.indexOf("quota") ));
+        	double spoolUsage1 = Double.parseDouble( ((ArrayList<String>)tableRow1).get( COLUMN_NAME_OVERRIDE.indexOf("Spool Usage (MB)") ));
+        	double spoolQuota1 = Double.parseDouble( ((ArrayList<String>)tableRow1).get( COLUMN_NAME_OVERRIDE.indexOf("Spool Quota (MB)") ));
         	double utilisation1 = (spoolQuota1 > 0) ? (spoolUsage1 / spoolQuota1) * 100 : 0;
 
-        	double spoolUsage2 = Double.parseDouble( ((ArrayList<String>)tableRow2).get( RESPONSE_COLUMNS.indexOf("current-spool-usage-in-mb") ));
-        	double spoolQuota2 = Double.parseDouble( ((ArrayList<String>)tableRow2).get( RESPONSE_COLUMNS.indexOf("quota") ));
+        	double spoolUsage2 = Double.parseDouble( ((ArrayList<String>)tableRow2).get( COLUMN_NAME_OVERRIDE.indexOf("Spool Usage (MB)") ));
+        	double spoolQuota2 = Double.parseDouble( ((ArrayList<String>)tableRow2).get( COLUMN_NAME_OVERRIDE.indexOf("Spool Quota (MB)") ));
         	double utilisation2 = (spoolQuota2 > 0) ? (spoolUsage2 / spoolQuota2) * 100 : 0;
 
             return Double.compare(utilisation2, utilisation1);	
         }
     }
     
+    // For connected clients of non-exclusive TEs, how to sort the flow ID to only show the first entry?
+    static class FlowIDComparator implements Comparator<Object>
+    {
+        @SuppressWarnings("unchecked")
+		public int compare(Object tableRow1, Object tableRow2)
+        {
+        	long flowID1 = Long.parseLong( ((ArrayList<String>)tableRow1).get( RESPONSE_COLUMNS_L2.indexOf("flow-id") ));
+        	long flowID2 = Long.parseLong( ((ArrayList<String>)tableRow2).get( RESPONSE_COLUMNS_L2.indexOf("flow-id") ));
+            
+        	return Long.compare(flowID1, flowID2);	
+        }
+    }
     /**
      * This method is called after initialisation but before the monitor is started.
      * 
@@ -224,10 +238,39 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
         responseHandler = new SampleResponseHandler();
         
         // create SEMP parser with the name of the element that contains the records
-		multiRecordParser = new TargetedMultiRecordSEMPParser(RESPONSE_ELEMENT_NAME_ROWS, RESPONSE_COLUMNS, RESPONSE_ELEMENT_NAMES_IGNORE);
-		
+        multiRecordParser = new TargetedMultiRecordSEMPParser(
+				RESPONSE_ELEMENT_NAME_ROWS, RESPONSE_COLUMNS, RESPONSE_ELEMENT_NAMES_IGNORE, 
+				RESPONSE_ELEMENT_NAME_ROWS_L2, RESPONSE_COLUMNS_L2);		
 	}
         
+	private void setDesiredColumnOrder (List<String> currentColumnNames) {
+	    
+		desiredColumnOrder = Arrays.asList(
+				currentColumnNames.indexOf("RowUID"), currentColumnNames.indexOf("name"), currentColumnNames.indexOf("message-vpn"),
+				currentColumnNames.indexOf("num-messages-spooled"), currentColumnNames.indexOf("current-spool-usage-in-mb"), currentColumnNames.indexOf("quota"), currentColumnNames.indexOf("high-water-mark-in-mb"),
+				currentColumnNames.indexOf("total-delivered-unacked-msgs"), currentColumnNames.indexOf("bind-count"), currentColumnNames.indexOf("max-bind-count"), currentColumnNames.indexOf("access-type"), 
+				currentColumnNames.indexOf("destination"), currentColumnNames.indexOf("durable"), currentColumnNames.indexOf("owner"), currentColumnNames.indexOf("ingress-config-status"), currentColumnNames.indexOf("egress-config-status"),
+				currentColumnNames.indexOf("oldest-msg-id"), currentColumnNames.indexOf("newest-msg-id"), currentColumnNames.indexOf("respect-ttl"), currentColumnNames.indexOf("max-ttl"), 
+				currentColumnNames.indexOf("reject-msg-to-sender-on-discard"), currentColumnNames.indexOf("max-redelivery"), currentColumnNames.indexOf("dead-message-queue")
+		);
+	}
+
+	private void submitSEMPQuery (String sempQuery, SampleSEMPParser sempParser) throws Exception {
+		
+		// Get the first SEMP query response...
+		HttpPost post = new HttpPost(HTTP_REQUEST_URI);
+		post.setHeader(HEADER_CONTENT_TYPE_UTF8);
+		post.setEntity(new ByteArrayEntity(sempQuery.getBytes("UTF-8")));
+		
+		
+		SampleHttpSEMPResponse resp = httpClient.execute(post, responseHandler);
+        if (resp.getStatusCode() != 200) {
+        	throw new Exception("Error occurred while sending request: " + resp.getStatusCode() 
+        			+ " - " + resp.getReasonPhrase());
+        }	        
+        String respBody = resp.getRespBody();        
+        sempParser.parse(respBody);
+	}
 	/**
 	 * This method is responsible to collect data required for a view.
 	 * @return The next monitor state which should be State.REPORTING_QUEUE.
@@ -241,56 +284,72 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
 		
 		LinkedHashMap<String, Object> headlines;
 		
-		// Construct table content
-		HttpPost post = new HttpPost(HTTP_REQUEST_URI);
-		post.setHeader(HEADER_CONTENT_TYPE_UTF8);
-		post.setEntity(new ByteArrayEntity(SHOW_USERS_REQUEST.getBytes("UTF-8")));
+		submitSEMPQuery(SHOW_TES_REQUEST, multiRecordParser);
 		
-		
-		SampleHttpSEMPResponse resp = httpClient.execute(post, responseHandler);
-		
-        if (resp.getStatusCode() != 200) {
-
-        	throw new Exception("Error occurred while sending request: " + resp.getStatusCode() 
-        			+ " - " + resp.getReasonPhrase());
-        }	        
-        String respBody = resp.getRespBody();        
-		multiRecordParser.parse(respBody);
-		
+		List<String> currentColumnNames = multiRecordParser.getColumnNames();
 		
 		// Will take what is received as the table contents and then do further Java8 Streams based filtering... 
-		this.receivedTableContent = multiRecordParser.getTableContent();
-		
+		receivedTableContent = multiRecordParser.getTableContent();
 		
 		// Need to do some cleanup on the received table as two optional output fields cause some disjointed column alignment
-		Vector<Object> goodTableContent = new Vector<Object>();
-		Vector<Object> brokenTableContent = new Vector<Object>();
+		Vector<ArrayList<String>> goodTableContent = new Vector<ArrayList<String>>();
+		Vector<ArrayList<String>> brokenTableContent = new Vector<ArrayList<String>>();
 
 		// To detect that, the expected number of columns is the column names list size if everything got provided
 		
 		goodTableContent.addAll(
 				receivedTableContent
 				.stream()
-				.filter( tableRow -> ((ArrayList<String>)tableRow).size() == RESPONSE_COLUMNS.size())
-				.collect(Collectors.toCollection(Vector<Object>::new))
+				.filter( tableRow -> tableRow.size() == RESPONSE_COLUMNS.size())
+				.collect(Collectors.toCollection(Vector<ArrayList<String>>::new))
 			);
 				
 		brokenTableContent.addAll(
 				receivedTableContent
 				.stream()
-				.filter( tableRow -> ((ArrayList<String>)tableRow).size() == (RESPONSE_COLUMNS.size() - RESPONSE_PAD_COLUMN_NUMBERS.size()))
-				.collect(Collectors.toCollection(Vector<Object>::new))
+				.filter( tableRow -> tableRow.size() == (RESPONSE_COLUMNS.size() - RESPONSE_OPTIONAL_COLUMNS.size()))
+				.collect(Collectors.toCollection(Vector<ArrayList<String>>::new))
 			);
 		
-		// For the rows in the broken table, fix it by padding where necessary
-	    for (Integer columnNumberToPad : RESPONSE_PAD_COLUMN_NUMBERS) 
-	    { 		      
-			brokenTableContent.forEach(tableRow -> ((ArrayList<String>)tableRow).add(columnNumberToPad, ""));		
-	    }
+		// For the rows in the broken table, fix it by padding into the correct column position
+		// Note: Columns in the original response order still
+		
+		// First add the optional column names if missing from current response columns even
+		if (currentColumnNames.indexOf(RESPONSE_OPTIONAL_COLUMNS.get(0)) < 0) {
+			for (String optionalColumn : RESPONSE_OPTIONAL_COLUMNS) {
+				currentColumnNames.add(optionalColumn);	
+			}
+		}
 
-
+		// Because of the optional columns being present or not changing between polls, need to set the column order each time:
+		setDesiredColumnOrder(currentColumnNames);	
+				
+		for (String optionalColumn : RESPONSE_OPTIONAL_COLUMNS) {			
+			brokenTableContent.forEach(tableRow -> tableRow.add(currentColumnNames.indexOf(optionalColumn), ""));	
+		}
+		
 		// Merge it all together now...
 		goodTableContent.addAll(brokenTableContent);
+		
+		// Reorder the merged table into the column order we want. 
+		Vector<ArrayList<String>> tempVpnLimitsTableContent = new Vector<ArrayList<String>>();
+		
+		// Iterate to each row in the table contents
+		for (int index = 0; index < goodTableContent.size(); index++) {
+			
+			// Build a new tableRow by adding to it in the right order 
+			ArrayList<String> tableRow = new ArrayList<String>();
+			
+			for (Integer columnNumber : this.desiredColumnOrder){
+				tableRow.add( goodTableContent.get(index).get(columnNumber));
+			}
+			// Add the newly created row to reorderedTableContent
+			tempVpnLimitsTableContent.add(tableRow); 
+		} 
+		goodTableContent = tempVpnLimitsTableContent;
+		
+		// NOTE: Table has been reordered from this point onwards. No further references to 'desiredColumnOrder' for column lookups
+		// All lookups should be based off 'COLUMN_NAME_OVERRIDE' and the user friendly column names, not the SEMP field name.
 		
 	    // If connected to the broker that is in Active-Standby Role of 'Standby', several other columns are missing in the response. e.g. bind-count.
 	    // This situation can be detected if the received table content was non-zero, yet the final 'good' table content is empty.
@@ -300,7 +359,7 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
 		isStandbyBrokerBefore = (isStandbyBrokerBefore == -1) ? isStandbyBrokerNow : isStandbyBrokerBefore;
 		
 		// Reset any previously saved table state
-		tablesPerView = new HashMap<String, Vector<Object>>();		
+		tablesPerView = new HashMap<String, Vector<ArrayList<String>>>();		
 	
 		// Split into per-VPN datasets if split mode selected
 		if (multiview)
@@ -311,7 +370,7 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
 			detectedVpns.addAll(
 				goodTableContent
 				.stream()
-				.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("message-vpn") ) )
+				.map( tableRow -> tableRow.get( RESPONSE_COLUMNS.indexOf("message-vpn") ) )
 				.distinct()
 				.collect(Collectors.toCollection(ArrayList<String>::new))
 				);
@@ -330,8 +389,8 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
 				tablesPerView.put(vpnName, 
 						goodTableContent
 						.stream()
-						.filter(tableRow -> vpnName.equalsIgnoreCase( ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("message-vpn") )    ) )
-						.collect(Collectors.toCollection(Vector<Object>::new))
+						.filter(tableRow -> vpnName.equalsIgnoreCase( tableRow.get( RESPONSE_COLUMNS.indexOf("message-vpn") )    ) )
+						.collect(Collectors.toCollection(Vector<ArrayList<String>>::new))
 					);	
 			}
 						
@@ -361,7 +420,7 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
 				long endpointsWithMsgs = 
 						goodTableContent
 						.stream()
-						.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("num-messages-spooled") ) )	// Only num-messages-spooled column
+						.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Messages Spooled") ) )	// Only num-messages-spooled column
 						.mapToInt(Integer::parseInt)
 						.filter(x -> x > 0) 		// Only the non-zero entries
 						.count() ;
@@ -369,7 +428,7 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
 				long endpointsWithBinds = 
 						goodTableContent
 						.stream()
-						.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("bind-count") ) )	// Only bind-count column
+						.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Bind Count") ) )	// Only bind-count column
 						.mapToInt(Integer::parseInt)
 						.filter(x -> x > 0) 		// Only the non-zero entries
 						.count() ;
@@ -377,7 +436,7 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
 				long endpointsWithZeroBinds = 
 						goodTableContent
 						.stream()
-						.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("bind-count") ) )	// Only bind-count column
+						.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Bind Count") ) )	// Only bind-count column
 						.mapToInt(Integer::parseInt)
 						.filter(x -> x == 0) 		// Only the non-zero entries
 						.count() ;
@@ -385,14 +444,14 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
 				long sumEndpointsMsgs = 
 						goodTableContent
 						.stream()
-						.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("num-messages-spooled") ) )	// Only num-messages-spooled column
+						.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Messages Spooled") ) )	// Only num-messages-spooled column
 						.mapToLong(Long::parseLong) 	
 						.sum() ;
 				
 				double sumSpoolUsage = 
 						goodTableContent
 						.stream()
-						.map( tableRow -> ((ArrayList<String>)tableRow).get( RESPONSE_COLUMNS.indexOf("current-spool-usage-in-mb") ) )	// Only current-spool-usage-in-mb column
+						.map( tableRow -> tableRow.get( COLUMN_NAME_OVERRIDE.indexOf("Spool Usage (MB)") ) )	// Only current-spool-usage-in-mb column
 						.mapToDouble(Double::parseDouble)	
 						.sum() ;
 				
@@ -405,51 +464,119 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
 				headlines.put("Total Topic Endpoints Count", goodTableContent.size());
 				
 				// Sort the list to show entries needing attention near to the top. Then also limit to the max row count if exceeding it...
-				Vector<Object> tempTableContent = new Vector<Object>();
+				Vector<ArrayList<String>> tempTableContent = new Vector<ArrayList<String>>();
+				Vector<ArrayList<String>> tempTableContentClients;
 				
 				tempTableContent.addAll(
 						goodTableContent
 						.stream()
 						.sorted(new TopicEndpointsComparator())
 						.limit(maxRows)				// Then cut the rows at max limit
-						.collect(Collectors.toCollection(Vector<Object>::new))
+						.collect(Collectors.toCollection(Vector<ArrayList<String>>::new))
 						);
 				
 				goodTableContent = tempTableContent;
 
 				
 				// Pretty up the MB usage numbers. Get the value, format it, set it back. NOTE: Do it as close to the final step towards publishing the table
-			    for (Integer columnNumberToFormat : RESPONSE_NUMBER_FORMAT_COLUMN_NUMBERS) 
+			    for (String columnToNumberFormat : RESPONSE_NUMBER_FORMAT_COLUMNS) 
 			    { 		      
-			    	goodTableContent.forEach(tableRow -> ((ArrayList<String>)tableRow)
-			    			.set(columnNumberToFormat, 
+			    	goodTableContent.forEach(tableRow -> tableRow
+			    			.set(COLUMN_NAME_OVERRIDE.indexOf(columnToNumberFormat), 
 			    					String.format(FLOAT_FORMAT_STYLE, 
 			    							Double.parseDouble(
-			    									((ArrayList<String>)tableRow).get(columnNumberToFormat)
+			    									tableRow.get(COLUMN_NAME_OVERRIDE.indexOf(columnToNumberFormat))
 			    									)
 			    							) 
 			    					)
 							);	
 			    }
 			    
-				// Finally, reorder data into the column order we want versus what came from the parser
-				Vector<Object> reorderedTableContent = new Vector<Object>();
-				// Iterate to each row in the table contents
+			    // Finally, for the final list of queues, annotate with extra columns with details of the bound consumer only if bind-count=1
+				tempTableContent = new Vector<ArrayList<String>>();
+				List<String> tempL2ColumnNames;
+				String rowUID;
+				
 				for (int index = 0; index < goodTableContent.size(); index++) {
 					
-					// Build a new tableRow by adding to it in the right order 
-					ArrayList<String> tableRow = new ArrayList<String>();
-					
-					for (Integer columnNumber : this.DESIRED_COLUMN_ORDER){
-						tableRow.add( ((ArrayList<String>)goodTableContent.get(index)).get(columnNumber));
+					// Build a new tableRow by adding to it with necessary annotations 
+					ArrayList<String> tableRow = goodTableContent.get(index);
+					String bindCount = tableRow.get(COLUMN_NAME_OVERRIDE.indexOf("Bind Count"));
+					String accessType = tableRow.get(COLUMN_NAME_OVERRIDE.indexOf("Access Type"));
+										
+					String clientID = "";
+					String isActive = "";
+					String windowSize = "";
+					String connectTime = "";
+					String flowID = "";
+					String lastMsgIDDelivered = "";
+					// These last two will stay empty fields since geneos rules populate them, not this monitor directly
+					String lastSeenClientID = "";
+					String lastSeenConnectTime = "";
+				
+					if (!bindCount.equalsIgnoreCase("0")) {
+												
+						rowUID = tableRow.get(COLUMN_NAME_OVERRIDE.indexOf("RowUID"));
+						tempL2ColumnNames = multiRecordParser.getColumnNamesLevel2();
+						tempTableContentClients = multiRecordParser.getTableContentLevel2(rowUID);
+						
+						if (tempTableContentClients.size() > 0) {
+							
+							// Which client to show in a single line available?
+							// If exclusive mode, show the one that is Active-Consumer
+							// If non-exclusive mode, show the lowest flow id?
+							
+							ArrayList<String> tableRowClient;
+							
+							if (bindCount.equalsIgnoreCase("1")) {
+								// Just one bind, so first (and only) entry in the table
+								tableRowClient = tempTableContentClients.get(0);
+							}
+							else {
+								// Bit more complicated, several to pick from but need to be deterministic between polls
+								if (accessType.equalsIgnoreCase("exclusive")) {
+									// Get the client that is active consuming
+									tableRowClient = tempTableContentClients
+											.stream()
+											.filter(x -> x.get(RESPONSE_COLUMNS_L2.indexOf("is-active")).equalsIgnoreCase("Active-Consumer"))
+											.limit(1)
+											.collect(Collectors.toList()).get(0);
+								}
+								else {
+									// Get the lowest flow ID (so earliest connected) of the set
+									tableRowClient = tempTableContentClients
+											.stream()
+											.sorted(new FlowIDComparator())
+											.limit(1)
+											.collect(Collectors.toList()).get(0);
+								}
+							}
+														
+							clientID = tableRowClient.get(tempL2ColumnNames.indexOf("name"));
+							isActive = tableRowClient.get(tempL2ColumnNames.indexOf("is-active"));
+							windowSize = tableRowClient.get(tempL2ColumnNames.indexOf("window-size"));
+							connectTime = tableRowClient.get(tempL2ColumnNames.indexOf("connect-time"));
+							flowID = tableRowClient.get(tempL2ColumnNames.indexOf("flow-id"));
+							lastMsgIDDelivered = tableRowClient.get(tempL2ColumnNames.indexOf("last-msg-id-delivered"));
+						}
 					}
-					// Add the newly created row to reorderedTableContent
-					reorderedTableContent.add(tableRow); 
+					tableRow.add(clientID);
+					tableRow.add(isActive);
+					tableRow.add(windowSize);
+					tableRow.add(connectTime);
+					tableRow.add(flowID);
+					tableRow.add(lastMsgIDDelivered);
+					tableRow.add(lastSeenClientID);
+					tableRow.add(lastSeenConnectTime);
+					
+					// Add the newly created row to tempTableContent
+					tempTableContent.add(tableRow); 
 				}  
+				goodTableContent = tempTableContent;
 				
 				// Table content all complete now for publishing. Just add the column names too.
-				reorderedTableContent.add(0, this.COLUMN_NAME_OVERRIDE);	// No longer as received from parser in receivedColumnNames
-				tablesPerView.put(viewKey, reorderedTableContent);
+				goodTableContent.add(0, this.COLUMN_NAME_OVERRIDE);	// No longer as received from parser in receivedColumnNames
+				tablesPerView.put(viewKey, goodTableContent);
 				headlinesPerView.put(viewKey, headlines);	
 				
 			}
@@ -458,7 +585,7 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
 				// There is no content for this view, either no endpoints in the VPN, or its a Standby role broker
 				// If Standby broker, add a message to signal this clearly
 				if (isStandbyBrokerNow == 1) {
-					Vector<Object> messageTableContent = new Vector<Object>();
+					Vector<ArrayList<String>> messageTableContent = new Vector<ArrayList<String>>();
 					ArrayList<String> tableRow; 
 					
 					tableRow = new ArrayList<String>();
@@ -495,7 +622,10 @@ public class TopicEndpointsExMonitor extends BaseMonitor implements MonitorConst
         					isStandbyBrokerBefore = isStandbyBrokerNow;
     					}
     					view.setHeadlines(headlinesPerView.get(view.getName()));
-        				view.setTableContent(tablesPerView.get(view.getName()));
+    					// The .setTableContent() method forces a Vector of Object!
+    					Vector<Object> submitTable = new Vector<Object>();
+    					submitTable.addAll(tablesPerView.get(view.getName()));
+        				view.setTableContent(submitTable);
     				}
     				else
     				{


### PR DESCRIPTION
**Enhancements:**

1. The `QueuesEx` and `TopicEndpointsEx` monitors have additional columns to show details of the bound consumer.

**Updates:**

1. Update to  SEMP parser to allow processing of records nested an additional level deep
2. Update to default polling intervals to some monitors to reduce SEMP polling load
3. Additional Geneos rules to track details of disconnected consumers on the endpoint monitors
